### PR TITLE
Increase cmake version for C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0096 NEW) # preserve leading zeroes in version components
 
 # project / version


### PR DESCRIPTION
CMake 3.20 is required for C++23.