### PR TITLE
Improve PS2 region detection

### DIFF
--- a/systems/system_ps2.ixx
+++ b/systems/system_ps2.ixx
@@ -132,14 +132,21 @@ private:
 	{
 		std::string region;
 
-		//FIXME: review all possible values
-		const std::set<std::string> REGION_J {"ESPM", "PAPX", "PCPX", "PDPX", "SCPM", "SCPS", "SCZS", "SIPS", "SLKA", "SLPM", "SLPS"};
-		const std::set<std::string> REGION_U {"LSP", "PEPX", "SCUS", "SLUS", "SLUSP"};
-		const std::set<std::string> REGION_E {"PUPX", "SCED", "SCES", "SLED", "SLES"};
-		// multi: "DTL", "PBPX"
+		// All Internal serials currently in redump.org
+		const std::set<std::string> REGION_J {"PAPX", "PCPX", "PDPX", "PSXC", "SCAJ", "SCPM", "SCPN", "SCPS", "SLAJ", "SLPM", "SLPS", "SRPM"};
+		const std::set<std::string> REGION_K {"SCKA", "SLKA"};
+		const std::set<std::string> REGION_C {"SCCS"};
+		const std::set<std::string> REGION_U {"PUPX", "SCUS", "SLUS"};
+		const std::set<std::string> REGION_E {"SCED", "SCES", "SLED", "SLES", "TCES"};
+		// multi region: "PBPX"
+		// preprod only: "ABCD", "XXXX"
 
 		if(REGION_J.find(prefix) != REGION_J.end())
 			region = "Japan";
+		else if(REGION_K.find(prefix) != REGION_K.end())
+			region = "South Korea";
+		else if(REGION_C.find(prefix) != REGION_C.end())
+			region = "China";
 		else if(REGION_U.find(prefix) != REGION_U.end())
 			region = "USA";
 		else if(REGION_E.find(prefix) != REGION_E.end())

--- a/systems/system_psx.ixx
+++ b/systems/system_psx.ixx
@@ -173,8 +173,8 @@ private:
 		std::string region;
 
 		const std::set<std::string> REGION_J {"ESPM", "PAPX", "PCPX", "PDPX", "SCPM", "SCPS", "SCZS", "SIPS", "SLKA", "SLPM", "SLPS"};
-		const std::set<std::string> REGION_U {"LSP", "PEPX", "SCUS", "SLUS", "SLUSP"};
-		const std::set<std::string> REGION_E {"PUPX", "SCED", "SCES", "SLED", "SLES"};
+		const std::set<std::string> REGION_U {"LSP", "PUPX", "SCUS", "SLUS", "SLUSP"};
+		const std::set<std::string> REGION_E {"PEPX", "SCED", "SCES", "SLED", "SLES"};
 		// multi: "DTL", "PBPX"
 
 		if(REGION_J.find(prefix) != REGION_J.end())


### PR DESCRIPTION
I have added all the PS2 Internal Serial prefixes currently in redump.org according to their region.

I have also added two regions: Korea and China. China because they have a different region lockout (NTSC-C), and Korea as SCEI did not allocate their serials (SCEK did). However, I have put Asian serial prefixes (SLAJ/SCAJ) under Japan as they were allocated by SCEI. If you would prefer Korea/China be under Japan or if you would prefer Asia to be its own region, I can change it.

Also, I have removed the following serial prefixes that do not exist as PS2 internal serials on redump, only as PSX serials:
ESPM, PEPX, LSP, DTL, SLUSP, SCZS, SIPS
If you know of a disc that has one of these as internal serial that I am not aware of, I will add it back.

Finally, PEPX and PUPX were the wrong way around in PSX region detection.