### PR TITLE
Add HL-DT-ST BD-RE BH16NS55 1.02 as an ASUS 3MB cache drive variant

### DIFF
--- a/drive.ixx
+++ b/drive.ixx
@@ -177,6 +177,7 @@ static const std::vector<DriveConfig> KNOWN_DRIVES =
 	{"ATAPI"   , "iHBS112 2"      , "PL06", "2012/09/17 10:50"   , +6, 0, -135, DriveConfig::ReadMethod::BE_CDDA, DriveConfig::SectorOrder::DATA_C2_SUB, DriveConfig::Type::LG_ASU8}, // CHECKED: LITE-ON
 	{"HL-DT-ST", "BD-RE BU40N"    , "1.00", "N003103MOAL36D3653" , +6, 0, -135, DriveConfig::ReadMethod::BE_CDDA, DriveConfig::SectorOrder::DATA_C2_SUB, DriveConfig::Type::LG_ASU83},// RibShark
 	{"ASUS"    , "BW-16D1HT"      , "3.02", "W000800KL8J9NJ3134" , +6, 0, -135, DriveConfig::ReadMethod::BE_CDDA, DriveConfig::SectorOrder::DATA_C2_SUB, DriveConfig::Type::LG_ASU3}, // CHECKED
+	{"HL-DT-ST", "BD-RE BH16NS55" , "1.02", "N000200SIK92G9OF211", +6, 0, -135, DriveConfig::ReadMethod::BE_CDDA, DriveConfig::SectorOrder::DATA_C2_SUB, DriveConfig::Type::LG_ASU8}, // TheMuso
 	{"HL-DT-ST", "BD-RE BP50NB40" , "1.00", "N005505MD8F8BD0700" , +6, 0, -135, DriveConfig::ReadMethod::BE_CDDA, DriveConfig::SectorOrder::DATA_C2_SUB, DriveConfig::Type::LG_ASU3}, // olofolleola4
 	{"Slimtype", "BD E DS4E1S"    , "EA2B", "2009/11/13 15:21"   , +6, 0, -135, DriveConfig::ReadMethod::BE_CDDA, DriveConfig::SectorOrder::DATA_C2_SUB, DriveConfig::Type::LG_ASU2}, // olofolleola4
 	{"Optiarc", "BD RW BD-5300S"  , "2.03", "2012/02/07 11:25"   , +6, 0, -135, DriveConfig::ReadMethod::BE_CDDA, DriveConfig::SectorOrder::DATA_C2_SUB, DriveConfig::Type::LG_ASU8}, // olofolleola4


### PR DESCRIPTION
This ASUS drive variant is also supported and works with DiscImageCreator. Happy to provide anything else you would like for verification. I've tested with mixed mode, data, and audio CDs without issue.