### PR TITLE
Prevent trailing spaces from appearing in the log file.

### DIFF
--- a/cd/cd_dump.ixx
+++ b/cd/cd_dump.ixx
@@ -1031,7 +1031,7 @@ export bool redumper_dump_cd(Context &ctx, const Options &options, bool refine)
 	LOGC_RF("");
 	LOG("");
 
-	LOG("media errors: ");
+	LOG("media errors:");
 	LOG("  SCSI: {}", errors_scsi);
 	LOG("  C2: {}", errors_c2);
 	LOG("  Q: {}", errors_q);
@@ -1190,7 +1190,7 @@ void redumper_rings(const Options &options)
 				rings.emplace_back(ring_start, lba_leadout - 1);
 
 			LOG("");
-			LOG("pass rings: ");
+			LOG("pass rings:");
 			for(auto const &r : rings)
 				LOG("{}-{}", r.first, r.second);
 		}

--- a/drive.ixx
+++ b/drive.ixx
@@ -396,7 +396,7 @@ export bool drive_is_asus(const DriveConfig &drive_config)
 export void print_supported_drives()
 {
 	LOG("");
-	LOG("supported drives: ");
+	LOG("supported drives:");
 	for(auto const &di : KNOWN_DRIVES)
 		if(di.type != DriveConfig::Type::GENERIC)
 			LOG("{}", drive_info_string(di));

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -733,7 +733,7 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, DumpMode dum
 	}
 	LOG("");
 
-	LOG("media errors: ");
+	LOG("media errors:");
 	LOG("  SCSI: {}", errors_scsi);
 
 	if(signal.interrupt())

--- a/dvd/dvd_key.ixx
+++ b/dvd/dvd_key.ixx
@@ -116,7 +116,7 @@ export void dvd_key(Context &ctx, const Options &options)
 		auto ci = (READ_DVD_STRUCTURE_CopyrightInformation *)copyright.data();
 		auto cpst = (READ_DVD_STRUCTURE_CopyrightInformation_CPST)ci->copyright_protection_system_type;
 
-		LOG("copyright: ");
+		LOG("copyright:");
 
 		std::string protection("unknown");
 		if(cpst == READ_DVD_STRUCTURE_CopyrightInformation_CPST::NONE)

--- a/split.ixx
+++ b/split.ixx
@@ -1287,7 +1287,7 @@ export void redumper_split(Context &ctx, Options &options)
 		
 		if(data_track)
 		{
-			LOG("data disc detected, offset configuration: ");
+			LOG("data disc detected, offset configuration:");
 			for(auto const &o : sync_records)
 			{
 				MSF msf = LBA_to_BCDMSF(o.lba);
@@ -1527,7 +1527,7 @@ export void redumper_split(Context &ctx, Options &options)
 
 	if(!scrap && offsets.size() > 1)
 	{
-		LOG("offset shift correction applied: ");
+		LOG("offset shift correction applied:");
 		for(auto const &o : offsets)
 			LOG("  LBA: {:6}, offset: {:+}", o.first, o.second);
 		LOG("");


### PR DESCRIPTION
It's not good form to have spaces appearing after the content and before the linefeed and a pet peeve of mine.
My editor is set to highlight them so that I don't save anything with them.

While the changes are trivial, I hope you accept them so that I won't have to keep removing the trailing spaces myself.

I looked for all places where trailing spaces appear and serve no purpose (e. g. there won't be content following on the same line) and removed them.

![spaces](https://github.com/superg/redumper/assets/6818198/c9a078be-17c6-4b70-85e1-e5bbdd7e27cc)


