### PR TITLE
Account for disc offset when shifting lead-in

### DIFF
--- a/cd/split.ixx
+++ b/cd/split.ixx
@@ -1287,7 +1287,7 @@ export void redumper_split(Context &ctx, Options &options)
         auto &s = toc.sessions[i];
         auto &t = s.tracks.front();
 
-        int32_t leadin_start = i ? toc.sessions[i - 1].tracks.back().lba_end : sample_to_lba(nonzero_data_range.first);
+        int32_t leadin_start = i ? toc.sessions[i - 1].tracks.back().lba_end : sample_to_lba(nonzero_data_range.first, offset_manager->getOffset(sample_to_lba(nonzero_data_range.first)));
         int32_t leadin_end = i ? t.indices.front() : 0;
 
         // do this before new track insertion


### PR DESCRIPTION
Retains all data in pre-gap by shifting the start of lead-in back by the disc offset.

Solves #133 and #134 as all the data is retained and the tracks match the universal hash. Track split locations may seem unusual, due to the nonstandard presence of data in the lead-out, but this is a separate issue than data being lost.