### PR TITLE
Add DC system to info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ target_sources(redumper
     "systems/securom.ixx"
     "systems/s_cdrom.ixx"
     "systems/s_iso.ixx"
+    "systems/dc.ixx"
     "systems/mcd.ixx"
     "systems/psx.ixx"
     "systems/ps2.ixx"

--- a/systems/dc.ixx
+++ b/systems/dc.ixx
@@ -1,0 +1,150 @@
+module;
+
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <map>
+#include <ostream>
+#include <set>
+#include <string_view>
+#include <vector>
+#include "system.hh"
+
+export module systems.dc;
+
+import filesystem.iso9660;
+import readers.sector_reader;
+import utils.hex_bin;
+import utils.misc;
+import utils.strings;
+
+
+
+namespace gpsxre
+{
+
+export class SystemDC : public System
+{
+public:
+    std::string getName() override
+    {
+        return "DC";
+    }
+
+    Type getType() override
+    {
+        return Type::ISO;
+    }
+
+    void printInfo(std::ostream &os, SectorReader *sector_reader, const std::filesystem::path &) const override
+    {
+        auto system_area = iso9660::Browser::readSystemArea(sector_reader);
+        if(system_area.size() < _ROM_HEADER_OFFSET + sizeof(ROMHeader) || memcmp(system_area.data(), _SYSTEM_MAGIC.data(), _SYSTEM_MAGIC.size()))
+            return;
+
+        std::vector<uint8_t> rom_header_data(system_area.data() + _ROM_HEADER_OFFSET, system_area.data() + _ROM_HEADER_OFFSET + sizeof(ROMHeader));
+
+        auto rom_header = (ROMHeader *)rom_header_data.data();
+
+        std::string date = extractDate(std::string(rom_header->date, sizeof(rom_header->date)));
+        if(!date.empty())
+            os << std::format("  build date: {}", date) << std::endl;
+
+        std::string serial(rom_header->serial, sizeof(rom_header->serial));
+        erase_all_inplace(serial, ' ');
+        if(!serial.empty())
+            os << std::format("  serial: {}", serial) << std::endl;
+
+        std::string regions(rom_header->regions, sizeof(rom_header->regions));
+        erase_all_inplace(regions, ' ');
+
+        std::set<std::string> unique_regions;
+        for(auto r : regions)
+        {
+            auto it = _REGIONS.find(r);
+            if(it != _REGIONS.end())
+                unique_regions.insert(it->second);
+        }
+
+        if(!unique_regions.empty())
+        {
+            os << (unique_regions.size() == 1 ? "  region: " : "  regions: ");
+            bool comma = false;
+            for(auto r : unique_regions)
+            {
+                os << (comma ? ", " : "") << r;
+                comma = true;
+            }
+            os << std::endl;
+        }
+
+        os << "  header:" << std::endl;
+        os << std::format("{}", hexdump(system_area.data(), _ROM_HEADER_OFFSET, sizeof(ROMHeader)));
+    }
+
+private:
+    static constexpr std::string_view _SYSTEM_MAGIC = "SEGA SEGAKATANA";
+    static constexpr uint32_t _ROM_HEADER_OFFSET = 0x000;
+    static constexpr uint32_t _DATE_SYMBOLS = 8;
+    static constexpr uint32_t _YEAR_SYMBOLS = 4;
+    static constexpr uint32_t _MONTH_SYMBOLS = 2;
+    static constexpr uint32_t _DAY_SYMBOLS = 2;
+    static const std::map<char, std::string> _REGIONS;
+
+    struct ROMHeader
+    {
+        char system_name[16];
+        char maker_id[16];
+        char device_info[16];
+
+        char regions[3];
+        char reserved1[5];
+        char peripherals[8];
+
+        char serial[10];
+        char version[6];
+
+        char date[8];
+        char reserved2[8];
+
+        char exe_filename[16];
+        char disc_manufacturer[16];
+
+        char title[128];
+    };
+
+
+    std::string extractDate(std::string date) const
+    {
+        if(date.length() != _DATE_SYMBOLS)
+            return "";
+
+        auto year_index = str_to_uint64(std::string(date, 0, _YEAR_SYMBOLS));
+        if(!year_index || !number_is_year(*year_index))
+            return "";
+
+        auto month_index = str_to_uint64(std::string(date, 4, _MONTH_SYMBOLS));
+        if(!month_index || !number_is_month(*month_index))
+            return "";
+
+        auto day_index = str_to_uint64(std::string(date, 6, _DAY_SYMBOLS));
+        if(!day_index || !number_is_day(*day_index))
+            return "";
+
+        date.insert(4, "-");
+        date.insert(7, "-");
+
+        return date;
+    }
+};
+
+
+const std::map<char, std::string> SystemDC::_REGIONS = {
+    { 'J', "Japan"  },
+    { 'U', "USA"    },
+    { 'E', "Europe" }
+};
+
+}

--- a/systems/dc.ixx
+++ b/systems/dc.ixx
@@ -52,6 +52,10 @@ public:
         if(!date.empty())
             os << std::format("  build date: {}", date) << std::endl;
 
+        std::string version = extractVersion(std::string(rom_header->version, sizeof(rom_header->version)));
+        if(!version.empty())
+            os << std::format("  version: {}", version) << std::endl;
+
         std::string serial(rom_header->serial, sizeof(rom_header->serial));
         erase_all_inplace(serial, ' ');
         if(!serial.empty())
@@ -91,6 +95,7 @@ private:
     static constexpr uint32_t _YEAR_SYMBOLS = 4;
     static constexpr uint32_t _MONTH_SYMBOLS = 2;
     static constexpr uint32_t _DAY_SYMBOLS = 2;
+    static constexpr uint32_t _VERSION_SYMBOLS = 6;
     static const std::map<char, std::string> _REGIONS;
 
     struct ROMHeader
@@ -137,6 +142,28 @@ private:
         date.insert(7, "-");
 
         return date;
+    }
+
+
+    std::string extractVersion(std::string version) const
+    {
+        if(version.length() != _VERSION_SYMBOLS)
+            return "";
+
+        if(version[0] != 'V')
+            return "";
+
+        version.erase(0, 1);
+        erase_all_inplace(version, ' ');
+
+        for(uint32_t i = 0; i < str.length(); ++i)
+        {
+            char ch = str[i];
+            if(!std::isdigit(ch) && ch != '.')
+                return "";
+        }
+
+        return version;
     }
 };
 

--- a/systems/dc.ixx
+++ b/systems/dc.ixx
@@ -156,9 +156,9 @@ private:
         version.erase(0, 1);
         erase_all_inplace(version, ' ');
 
-        for(uint32_t i = 0; i < str.length(); ++i)
+        for(uint32_t i = 0; i < version.length(); ++i)
         {
-            char ch = str[i];
+            char ch = version[i];
             if(!std::isdigit(ch) && ch != '.')
                 return "";
         }

--- a/systems/systems.ixx
+++ b/systems/systems.ixx
@@ -8,6 +8,7 @@ export module systems.systems;
 
 import systems.cdrom;
 import systems.iso;
+import systems.dc;
 import systems.mcd;
 import systems.psx;
 import systems.ps2;
@@ -36,6 +37,7 @@ public:
         systems.push_back([]() { return std::make_unique<SystemCDROM>(); });
         systems.push_back([]() { return std::make_unique<SystemSecuROM>(); });
         systems.push_back([]() { return std::make_unique<SystemISO>(); });
+        systems.push_back([]() { return std::make_unique<SystemDC>(); });
         systems.push_back([]() { return std::make_unique<SystemMCD>(); });
         systems.push_back([]() { return std::make_unique<SystemPSX>(); });
         systems.push_back([]() { return std::make_unique<SystemPS2>(); });

--- a/utils/misc.ixx
+++ b/utils/misc.ixx
@@ -342,4 +342,10 @@ export bool number_is_month(uint32_t month)
     return month >= 1 && month <= 12;
 }
 
+
+export bool number_is_day(uint32_t day)
+{
+    return day >= 1 && day <= 31;
+}
+
 }


### PR DESCRIPTION
Adds Dreamcast as a supported system by `redumper info`
Fixes #137 

Based this off the MCD code, but with the changes required for the DC header.
Example output:
```
DC [Demolition Racer - No Exit (USA) (Demo) (Track 1).bin]:
  build date: 2000-07-10
  version: 0.800
  serial: T15112N
  region: USA
  header:
0000 : 53 45 47 41 20 53 45 47  41 4B 41 54 41 4E 41 20   SEGA SEGAKATANA
0010 : 53 45 47 41 20 45 4E 54  45 52 50 52 49 53 45 53   SEGA ENTERPRISES
0020 : 35 43 36 42 20 47 44 2D  52 4F 4D 31 2F 31 20 20   5C6B GD-ROM1/1
0030 : 20 55 20 20 20 20 20 20  30 37 38 31 41 31 30 20    U      0781A10
0040 : 54 31 35 31 31 32 4E 20  20 20 56 30 2E 38 30 30   T15112N   V0.800
0050 : 32 30 30 30 30 37 31 30  20 20 20 20 20 20 20 20   20000710
0060 : 31 53 54 5F 52 45 41 44  2E 42 49 4E 20 20 20 20   1ST_READ.BIN
0070 : 53 45 47 41 20 4C 43 2D  54 2D 31 35 31 20 20 20   SEGA LC-T-151
0080 : 44 45 4D 4F 4C 49 54 49  4F 4E 20 52 41 43 45 52   DEMOLITION RACER
0090 : 20 2D 20 4E 4F 20 45 58  49 54 20 49 4E 46 4F 47    - NO EXIT INFOG
00A0 : 52 41 4D 45 53 20 46 52  45 45 20 44 45 4D 4F 20   RAMES FREE DEMO
00B0 : 20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20
00C0 : 20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20
00D0 : 20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20
00E0 : 20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20
00F0 : 20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20
```