### PR TITLE
Abandon magic check with degenerate range

### DIFF
--- a/cd/split.ixx
+++ b/cd/split.ixx
@@ -50,6 +50,10 @@ int32_t byte_offset_by_magic(int32_t lba_start, int32_t lba_end, std::fstream &s
 {
     int32_t write_offset = std::numeric_limits<int32_t>::max();
 
+    if(lba_start > lba_end)
+    {
+        return write_offset;
+    }
     const uint32_t sectors_to_check = lba_end - lba_start;
 
     std::vector<uint8_t> data(sectors_to_check * CD_DATA_SIZE);


### PR DESCRIPTION
When track 1 is entirely zero, `byte_offset_by_magic()` can be called with `lba_end` (the end of track 1) less than `lba_start` (the first non-zero byte). This leaves an overflowed value in `sectors_to_check`, likely leading to OOM or another overflow in the allocation of `data`. This patch abandons the check early if the range is degenerate.