### PR TITLE
Add auto eject option

### DIFF
--- a/options.ixx
+++ b/options.ixx
@@ -25,6 +25,7 @@ export struct Options
     bool help;
     bool version;
     bool verbose;
+    bool auto_eject;
     bool debug;
 
     std::string image_path;
@@ -70,6 +71,7 @@ export struct Options
         : help(false)
         , version(false)
         , verbose(false)
+        , auto_eject(false)
         , debug(false)
         , overwrite(false)
         , force_split(false)
@@ -129,6 +131,8 @@ export struct Options
                         version = true;
                     else if(key == "--verbose")
                         verbose = true;
+                    else if(key == "--auto-eject")
+                        auto_eject = true;
                     else if(key == "--debug")
                         debug = true;
                     else if(key == "--image-path")
@@ -293,6 +297,7 @@ export struct Options
         LOG("\t--help,-h                      \tprint usage");
         LOG("\t--version                      \tprint version");
         LOG("\t--verbose                      \tverbose output");
+        LOG("\t--auto-eject                   \tauto eject after dump");
         LOG("\t--drive=VALUE                  \tdrive to use, first available drive with disc, if not provided");
         LOG("\t--speed=VALUE                  \tdrive read speed, optimal drive speed will be used if not provided");
         LOG("\t--retries=VALUE                \tnumber of sector retries in case of SCSI/C2 error (default: {})", retries);

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -366,10 +366,13 @@ export int redumper(Options &options)
     }
 
     std::chrono::seconds time_check = std::chrono::seconds::zero();
-    for(auto const &c : options.commands)
+    bool ejected = false;
+    for(auto it = options.commands.begin(); it != options.commands.end(); ++it)
     {
-        auto it = COMMAND_HANDLERS.find(c);
-        if(it == COMMAND_HANDLERS.end())
+        const auto &c = *it;
+
+        auto cmd = COMMAND_HANDLERS.find(c);
+        if(cmd == COMMAND_HANDLERS.end())
             throw_line("unknown command (command: {})", c);
 
         LOG("");
@@ -377,9 +380,32 @@ export int redumper(Options &options)
         LOG("");
 
         auto time_start = std::chrono::high_resolution_clock::now();
-        it->second.second(ctx, options);
+        cmd->second.second(ctx, options);
         auto time_stop = std::chrono::high_resolution_clock::now();
         time_check = std::chrono::duration_cast<std::chrono::seconds>(time_stop - time_start);
+
+        // if auto eject enabled, check if drive is no longer in use
+        if(options.eject && !ejected)
+        {
+            bool drive_complete = true;
+            for(auto next_it = std::next(it); next_it != options.commands.end(); ++next_it)
+            {
+                auto next_cmd = COMMAND_HANDLERS.find(*next_it);
+                if(next_cmd != COMMAND_HANDLERS.end() && next_cmd->second.first)
+                {
+                    drive_complete = false;
+                    break;
+                }
+            }
+            if(drive_complete)
+            {
+                // eject drive
+                auto status = cmd_start_stop_unit(*ctx.sptd, 1, 0);
+                if(status.status_code)
+                    LOG("warning: failed to eject, SCSI ({})", SPTD::StatusMessage(status));
+                ejected = true;
+            }
+        }
     }
     LOG("");
     LOG("*** END{}", time_check == std::chrono::seconds::zero() ? "" : std::format(" (time check: {}s)", time_check.count()));

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -385,7 +385,7 @@ export int redumper(Options &options)
         time_check = std::chrono::duration_cast<std::chrono::seconds>(time_stop - time_start);
 
         // if auto eject enabled, check if drive is no longer in use
-        if(options.eject && !ejected)
+        if(options.auto_eject && !ejected)
         {
             bool drive_complete = true;
             for(auto next_it = std::next(it); next_it != options.commands.end(); ++next_it)

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -201,17 +201,22 @@ std::string generate_image_name(std::string drive)
 }
 
 
-std::list<std::string> get_cd_batch_commands(Context &ctx, const std::string &command)
+std::list<std::string> get_cd_batch_commands(Context &ctx, const std::string &command, bool eject)
 {
     if(profile_is_cd(ctx.current_profile))
-        return command == "new" ? std::list<std::string>{ "dumpnew", "protection", "refinenew", "split", "hash", "info" }
-                                : std::list<std::string>{ "dump", "protection", "refine", "split", "hash", "info" };
+        return command == "new" ? eject ? std::list<std::string>{ "dumpnew", "protection", "refinenew", "eject", "split", "hash", "info" }
+                                        : std::list<std::string>{ "dumpnew", "protection", "refinenew", "split", "hash", "info" }
+                                : eject ? std::list<std::string>{ "dump", "protection", "refine", "eject", "split", "hash", "info" }
+                                        : std::list<std::string>{ "dump", "protection", "refine", "split", "hash", "info" };
     else if(profile_is_dvd(ctx.current_profile))
-        return std::list<std::string>{ "dump", "refine", "dvdkey", "hash", "info" };
+        return eject ? std::list<std::string>{ "dump", "refine", "dvdkey", "eject", "hash", "info" }
+                     : std::list<std::string>{ "dump", "refine", "dvdkey", "hash", "info" };
     else if(profile_is_bluray(ctx.current_profile))
-        return std::list<std::string>{ "dump", "refine", "hash", "info" };
+        return eject ? std::list<std::string>{ "dump", "refine", "eject", "hash", "info" }
+                     : std::list<std::string>{ "dump", "refine", "hash", "info" };
     else if(profile_is_hddvd(ctx.current_profile))
-        return std::list<std::string>{ "dump", "refine", "hash", "info" };
+        return eject ? std::list<std::string>{ "dump", "refine", "eject", "hash", "info" }
+                     : std::list<std::string>{ "dump", "refine", "hash", "info" };
     else
         return std::list<std::string>{};
 }
@@ -297,7 +302,7 @@ Context initialize(Options &options)
             options.commands.push_back(c);
         else
         {
-            auto cd_batch_commands = get_cd_batch_commands(ctx, c);
+            auto cd_batch_commands = get_cd_batch_commands(ctx, c, Options.auto_eject);
             options.commands.insert(options.commands.end(), cd_batch_commands.begin(), cd_batch_commands.end());
         }
     }

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -385,7 +385,7 @@ export int redumper(Options &options)
         time_check = std::chrono::duration_cast<std::chrono::seconds>(time_stop - time_start);
 
         // if auto eject enabled, check if drive is no longer in use
-        if(options.auto_eject && !ejected)
+        if(options.auto_eject && !ejected && ctx.sptd)
         {
             bool drive_complete = true;
             for(auto next_it = std::next(it); next_it != options.commands.end(); ++next_it)

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -366,7 +366,7 @@ export int redumper(Options &options)
     }
 
     std::chrono::seconds time_check = std::chrono::seconds::zero();
-    bool ejected = false;
+    bool ejected = !ctx.sptd;
     for(auto it = options.commands.begin(); it != options.commands.end(); ++it)
     {
         const auto &c = *it;
@@ -385,7 +385,7 @@ export int redumper(Options &options)
         time_check = std::chrono::duration_cast<std::chrono::seconds>(time_stop - time_start);
 
         // if auto eject enabled, check if drive is no longer in use
-        if(options.auto_eject && !ejected && ctx.sptd)
+        if(options.auto_eject && !ejected)
         {
             bool drive_complete = true;
             for(auto next_it = std::next(it); next_it != options.commands.end(); ++next_it)

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -140,6 +140,17 @@ void redumper_dvdkey(Context &ctx, Options &options)
 }
 
 
+void redumper_eject(Context &ctx, Options &options)
+{
+    if(ctx.sptd)
+    {
+        auto status = cmd_start_stop_unit(*ctx.sptd, 1, 0);
+        if(status.status_code)
+            LOG("warning: failed to eject, SCSI ({})", SPTD::StatusMessage(status));
+    }
+}
+
+
 const std::map<std::string, std::pair<bool, void (*)(Context &, Options &)>> COMMAND_HANDLERS{
     // COMMAND         DRIVE    HANDLER
     { "rings",      { true, redumper_rings }       },
@@ -149,6 +160,7 @@ const std::map<std::string, std::pair<bool, void (*)(Context &, Options &)>> COM
     { "refinenew",  { true, redumper_refine_new }  },
     { "verify",     { true, redumper_verify }      },
     { "dvdkey",     { true, redumper_dvdkey }      },
+    { "eject",      { true, redumper_eject }       },
     { "dvdisokey",  { false, redumper_dvdisokey }  },
     { "protection", { false, redumper_protection } },
     { "split",      { false, redumper_split }      },
@@ -203,6 +215,7 @@ std::string generate_image_name(std::string drive)
 
 std::list<std::string> get_cd_batch_commands(Context &ctx, const std::string &command, bool eject)
 {
+    // clang-format off
     if(profile_is_cd(ctx.current_profile))
         return command == "new" ? eject ? std::list<std::string>{ "dumpnew", "protection", "refinenew", "eject", "split", "hash", "info" }
                                         : std::list<std::string>{ "dumpnew", "protection", "refinenew", "split", "hash", "info" }
@@ -219,6 +232,7 @@ std::list<std::string> get_cd_batch_commands(Context &ctx, const std::string &co
                      : std::list<std::string>{ "dump", "refine", "hash", "info" };
     else
         return std::list<std::string>{};
+    // clang-format on
 }
 
 

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -316,7 +316,7 @@ Context initialize(Options &options)
             options.commands.push_back(c);
         else
         {
-            auto cd_batch_commands = get_cd_batch_commands(ctx, c, Options.auto_eject);
+            auto cd_batch_commands = get_cd_batch_commands(ctx, c, options.auto_eject);
             options.commands.insert(options.commands.end(), cd_batch_commands.begin(), cd_batch_commands.end());
         }
     }

--- a/scsi/cmd.ixx
+++ b/scsi/cmd.ixx
@@ -446,4 +446,16 @@ SPTD::Status cmd_get_configuration(SPTD &sptd)
     return status;
 }
 
+
+export SPTD::Status cmd_start_stop_unit(SPTD &sptd, uint8_t load_eject, uint8_t start)
+{
+    CDB6_StartStopUnit cdb = {};
+    cdb.operation_code = (uint8_t)CDB_OperationCode::START_STOP_UNIT;
+    cdb.load_eject = load_eject;
+    cdb.start = start;
+
+
+    return sptd.sendCommand(&cdb, sizeof(cdb), nullptr, 0);
+}
+
 }

--- a/scsi/mmc.ixx
+++ b/scsi/mmc.ixx
@@ -12,6 +12,7 @@ export enum class CDB_OperationCode : uint8_t
 {
     TEST_UNIT_READY = 0x00,
     INQUIRY = 0x12,
+    START_STOP_UNIT = 0x1B,
     READ_CAPACITY = 0x25,
     SYNCHRONIZE_CACHE = 0x35,
     READ_TOC = 0x43,
@@ -575,6 +576,23 @@ export struct CDB6_Inquiry
     uint8_t reserved1                 :6;
     uint8_t page_code;
     uint8_t allocation_length[2]; // unaligned
+    uint8_t control;
+};
+
+
+export struct CDB6_StartStopUnit
+{
+    uint8_t operation_code;
+    uint8_t immediate :1;
+    uint8_t reserved1 :7;
+    uint8_t reserved2;
+    uint8_t power_condition_modifier :4;
+    uint8_t reserved3                :4;
+    uint8_t start                    :1;
+    uint8_t load_eject               :1;
+    uint8_t no_flush                 :1;
+    uint8_t reserved4                :1;
+    uint8_t power_condition          :4;
     uint8_t control;
 };
 


### PR DESCRIPTION
This adds an auto eject option (`--auto-eject`) that will eject the disc once all the phases that use the disc are complete.
i.e. it will eject the disc after rings/dump/refine/verify/dvdkey is done, but redumper will continue with protection/split/hash/info/skeleton phases.

It ejects the disc by calling the scsi START_STOP_UNIT (0x1B) command which I have added to `scsi/cmd.ixx` and `scsi/mmc.ixx`

Fixes #190 and also fixes an issue with LG/ASUS (so-called UHD friendly drives) that have the sleep bug (the disc/drive makes terrible noises after a BDXL disc like PS5 & 4K-BD have been in the drive idle for a minute or two, which can happen during skeleton phase).

Also sorry for the many commits, best to squash merge.