### PR TITLE
RibShark FW detection

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - dev
   pull_request:
 
 env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,7 @@ name: CMake
 
 on:
   push:
-    branches:
-      - main
-      - dev
+    branches: [ main ]
   pull_request:
 
 env:

--- a/cd/cd_dump.ixx
+++ b/cd/cd_dump.ixx
@@ -764,9 +764,6 @@ export bool redumper_dump_cd(Context &ctx, const Options &options, bool refine)
                 }
 
                 store = true;
-
-                if(lba == lba_end && drive_is_asus_ribshark(ctx.drive_config))
-                    LOG_R("RibShark FW: Reading lead-out");
             }
         }
 
@@ -900,6 +897,9 @@ export bool redumper_dump_cd(Context &ctx, const Options &options, bool refine)
             // grow lead-out overread if we still can read
             if(lba + 1 == lba_overread && !options.lba_end && (lba_overread - lba_end <= 100 || options.overread_leadout))
                 ++lba_overread;
+
+            if(lba_overread == lba_end + 1 && drive_is_asus_ribshark(ctx.drive_config))
+                LOG_R("RibShark FW: Reading lead-out");
         }
         else
         {

--- a/cd/cd_dump.ixx
+++ b/cd/cd_dump.ixx
@@ -764,6 +764,9 @@ export bool redumper_dump_cd(Context &ctx, const Options &options, bool refine)
                 }
 
                 store = true;
+
+                if (lba == lba_end && drive_is_asus_ribshark(ctx.drive_config))
+                    LOG_R("RibShark FW: Reading lead-out");
             }
         }
 

--- a/cd/cd_dump.ixx
+++ b/cd/cd_dump.ixx
@@ -765,7 +765,7 @@ export bool redumper_dump_cd(Context &ctx, const Options &options, bool refine)
 
                 store = true;
 
-                if (lba == lba_end && drive_is_asus_ribshark(ctx.drive_config))
+                if(lba == lba_end && drive_is_asus_ribshark(ctx.drive_config))
                     LOG_R("RibShark FW: Reading lead-out");
             }
         }

--- a/cd/cd_dump.ixx
+++ b/cd/cd_dump.ixx
@@ -898,7 +898,7 @@ export bool redumper_dump_cd(Context &ctx, const Options &options, bool refine)
             if(lba + 1 == lba_overread && !options.lba_end && (lba_overread - lba_end <= 100 || options.overread_leadout))
                 ++lba_overread;
 
-            if(lba_overread == lba_end + 1 && drive_is_asus_ribshark(ctx.drive_config))
+            if(lba == lba_end + 10 && drive_is_asus_ribshark(ctx.drive_config))
                 LOG_R("RibShark FW: Reading lead-out");
         }
         else

--- a/dump.ixx
+++ b/dump.ixx
@@ -157,13 +157,8 @@ export TOC choose_toc(const std::vector<uint8_t> &toc_buffer, const std::vector<
 
 export bool drive_is_asus_ribshark(const DriveConfig &drive_config)
 {
-    return drive_config.vendor_id == "ASUS"
-           && drive_config.product_id == "BW-16D1HT"
-           && drive_config.product_revision_level == "3.10"
-           && drive_config.vendor_specific == "WM01601KLZL4TG5625"
-           && drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA
-           && drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB
-           && ctx.drive_config.type == DriveConfig::Type::GENERIC;
+    return drive_config.vendor_id == "ASUS" && drive_config.product_id == "BW-16D1HT" && drive_config.product_revision_level == "3.10" && drive_config.vendor_specific == "WM01601KLZL4TG5625"
+        && drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA && drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB && ctx.drive_config.type == DriveConfig::Type::GENERIC;
 }
 
 

--- a/dump.ixx
+++ b/dump.ixx
@@ -155,6 +155,18 @@ export TOC choose_toc(const std::vector<uint8_t> &toc_buffer, const std::vector<
 }
 
 
+export bool drive_is_asus_ribshark(const DriveConfig &drive_config)
+{
+    return drive_config.vendor_id == "ASUS"
+        && drive_config.product_id == "BW-16D1HT"
+        && drive_config.product_revision_level == "3.10"
+        && drive_config.vendor_specific == "WM01601KLZL4TG5625"
+        && drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA
+        && drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB
+        && ctx.drive_config.type == DriveConfig::Type::GENERIC;
+}
+
+
 export bool drive_is_plextor4824(const DriveConfig &drive_config)
 {
     return drive_config.vendor_id == "PLEXTOR" && drive_config.product_id == "CD-R PX-W4824A";

--- a/dump.ixx
+++ b/dump.ixx
@@ -157,13 +157,13 @@ export TOC choose_toc(const std::vector<uint8_t> &toc_buffer, const std::vector<
 
 export bool drive_is_asus_ribshark(const DriveConfig &drive_config)
 {
-    return drive_config.vendor_id == "ASUS"
-        && drive_config.product_id == "BW-16D1HT"
-        && drive_config.product_revision_level == "3.10"
-        && drive_config.vendor_specific == "WM01601KLZL4TG5625"
-        && drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA
-        && drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB
-        && ctx.drive_config.type == DriveConfig::Type::GENERIC;
+    return drive_config.vendor_id == "ASUS" &&
+           drive_config.product_id == "BW-16D1HT" &&
+           drive_config.product_revision_level == "3.10" &&
+           drive_config.vendor_specific == "WM01601KLZL4TG5625" &&
+           drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA &&
+           drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB &&
+           drive_config.type == DriveConfig::Type::GENERIC;
 }
 
 

--- a/dump.ixx
+++ b/dump.ixx
@@ -158,7 +158,7 @@ export TOC choose_toc(const std::vector<uint8_t> &toc_buffer, const std::vector<
 export bool drive_is_asus_ribshark(const DriveConfig &drive_config)
 {
     return drive_config.vendor_id == "ASUS" && drive_config.product_id == "BW-16D1HT" && drive_config.product_revision_level == "3.10" && drive_config.vendor_specific == "WM01601KLZL4TG5625"
-        && drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA && drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB && ctx.drive_config.type == DriveConfig::Type::GENERIC;
+        && drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA && drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB && drive_config.type == DriveConfig::Type::GENERIC;
 }
 
 

--- a/dump.ixx
+++ b/dump.ixx
@@ -157,7 +157,7 @@ export TOC choose_toc(const std::vector<uint8_t> &toc_buffer, const std::vector<
 
 export bool drive_is_asus_ribshark(const DriveConfig &drive_config)
 {
-    return drive_config.vendor_id == "ASUS" && drive_config.product_id == "BW-16D1HT" && drive_config.product_revision_level == "3.10" && drive_config.vendor_specific == "WM01601KLZL4TG5625"
+    return drive_config.vendor_id == "ASUS" && drive_config.product_id == "BW-16D1HT" && drive_config.product_revision_level == "3.10" && drive_config.vendor_specific.starts_with("WM01601")
         && drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA && drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB && drive_config.type == DriveConfig::Type::GENERIC;
 }
 

--- a/dump.ixx
+++ b/dump.ixx
@@ -157,13 +157,13 @@ export TOC choose_toc(const std::vector<uint8_t> &toc_buffer, const std::vector<
 
 export bool drive_is_asus_ribshark(const DriveConfig &drive_config)
 {
-    return drive_config.vendor_id == "ASUS" &&
-           drive_config.product_id == "BW-16D1HT" &&
-           drive_config.product_revision_level == "3.10" &&
-           drive_config.vendor_specific == "WM01601KLZL4TG5625" &&
-           drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA &&
-           drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB &&
-           drive_config.type == DriveConfig::Type::GENERIC;
+    return drive_config.vendor_id == "ASUS"
+           && drive_config.product_id == "BW-16D1HT"
+           && drive_config.product_revision_level == "3.10"
+           && drive_config.vendor_specific == "WM01601KLZL4TG5625"
+           && drive_config.read_method == DriveConfig::ReadMethod::BE_CDDA
+           && drive_config.sector_order == DriveConfig::SectorOrder::DATA_C2_SUB
+           && ctx.drive_config.type == DriveConfig::Type::GENERIC;
 }
 
 


### PR DESCRIPTION
Logs whenever a RibShark-fw-looking drive reads 10 sectors into the leadout. The assumption is that 3.10MK FW drives will not read that far into the leadout (minimising false positives), and that RibShark FW drives should almost always be able to read at least 10 leadout sectors (minimising false negatives).

I have tested this with the 3.10MK FW (which returns true for the `drive_is_asus_ribshark` function) and it did not log for a PC CD, PSX CD, and an Audio CD. I then flashed RibShark FW, and it logged it for all 3 discs.