### PR TITLE
Fix DVD split for xbox

### DIFF
--- a/dvd/dvd_split.ixx
+++ b/dvd/dvd_split.ixx
@@ -55,9 +55,8 @@ void generate_extra_xbox(Context &ctx, Options &options)
 
                     ROMEntry dmi_rom_entry(dmi_path.filename().string());
                     dmi_rom_entry.update(manufacturer.data(), DVD_DESCRIPTOR_SIZE);
-                    if(!ctx.dat.has_value())
-                        ctx.dat = std::vector<std::string>();
-                    ctx.dat->push_back(dmi_rom_entry.xmlLine());
+                    if(ctx.dat.has_value())
+                        ctx.dat->push_back(dmi_rom_entry.xmlLine());
                 }
                 else
                 {
@@ -85,9 +84,8 @@ void generate_extra_xbox(Context &ctx, Options &options)
 
                     ROMEntry pfi_rom_entry(pfi_path.filename().string());
                     pfi_rom_entry.update(physical.data(), DVD_DESCRIPTOR_SIZE);
-                    if(!ctx.dat.has_value())
-                        ctx.dat = std::vector<std::string>();
-                    ctx.dat->push_back(pfi_rom_entry.xmlLine());
+                    if(ctx.dat.has_value())
+                        ctx.dat->push_back(pfi_rom_entry.xmlLine());
                 }
                 else
                 {
@@ -112,9 +110,8 @@ void generate_extra_xbox(Context &ctx, Options &options)
 
                 ROMEntry ss_rom_entry(ss_path.filename().string());
                 ss_rom_entry.update(security.data(), DVD_DESCRIPTOR_SIZE);
-                if(!ctx.dat.has_value())
-                    ctx.dat = std::vector<std::string>();
-                ctx.dat->push_back(ss_rom_entry.xmlLine());
+                if(ctx.dat.has_value())
+                    ctx.dat->push_back(ss_rom_entry.xmlLine());
 
                 LOG("security sector ranges:");
                 auto security_ranges = get_security_sector_ranges((READ_DVD_STRUCTURE_LayerDescriptor &)security[0]);


### PR DESCRIPTION
Now only appends xbox extras (DMI/PFI/SS) to the context's dat if it already has the ISO hash.
Fixes an issue where Xbox/Xbox360 ISO hash was not printed if it contained errors in the initial dump that were later fixed in refine step.