### PR TITLE
Use cd split by default

### DIFF
--- a/redumper.ixx
+++ b/redumper.ixx
@@ -154,10 +154,10 @@ void redumper_eject(Context &ctx, Options &options)
 
 void redumper_split(Context &ctx, Options &options)
 {
-    if(profile_is_cd(ctx.current_profile))
-        redumper_split_cd(ctx, options);
-    else
+    if(profile_is_dvd(ctx.current_profile) || profile_is_bluray(ctx.current_profile) || profile_is_hddvd(ctx.current_profile))
         redumper_split_dvd(ctx, options);
+    else
+        redumper_split_cd(ctx, options);
 }
 
 


### PR DESCRIPTION
Currently redumper split falls back to the new dvd split if split is called on an image rather than during a dump. This change ensures that cd split is the default, unless the profile is dvd/bluray/hddvd.

Currently dvd split does not read from the state file at all, so running `split` standalone on an iso image is useless.
This check can be made smarter in the future if needed.