### PR TITLE
Fix skeleton issues

### DIFF
--- a/cd/cd_common.ixx
+++ b/cd/cd_common.ixx
@@ -651,7 +651,7 @@ export std::list<std::pair<std::string, TrackType>> cue_get_entries(const std::f
                 else if(tokens[2] == "MODE2/2324")
                     entry.second = TrackType::MODE2_2324;
                 else
-                    entry.second = TrackType::ISO;
+                    entry.second = TrackType::UNKNOWN;
                 entries.push_back(entry);
                 entry.first.clear();
             }

--- a/cd/cd_common.ixx
+++ b/cd/cd_common.ixx
@@ -43,21 +43,39 @@ export constexpr int32_t LBA_START = -45150; // MSVC internal compiler error: MS
 export constexpr uint32_t LEADOUT_OVERREAD_COUNT = 100;
 
 
-export enum class TrackType : uint8_t
+export enum class TrackType
 {
-    AUDIO = 0,
-    MODE1_2352 = 1,
-    MODE2_2352 = 2,
-    CDI_2352 = 3,
-    MODE1_2048 = 4,
-    MODE2_2336 = 5,
-    CDI_2336 = 6,
-    CDG = 7,
-    MODE0_2352 = 8,
-    MODE2_2048 = 9,
-    MODE2_2324 = 10,
-    ISO = 255
+    AUDIO,
+    MODE1_2352,
+    MODE2_2352,
+    CDI_2352,
+    MODE1_2048,
+    MODE2_2336,
+    CDI_2336,
+    CDG,
+    MODE0_2352,
+    MODE2_2048,
+    MODE2_2324,
+    UNKNOWN
 };
+
+
+export bool track_type_is_data_raw(TrackType track_type)
+{
+    return track_type == TrackType::MODE1_2352 || track_type == TrackType::MODE2_2352 || track_type == TrackType::CDI_2352 || track_type == TrackType::MODE0_2352;
+}
+
+
+export bool track_type_is_data_iso(TrackType track_type)
+{
+    return track_type == TrackType::MODE1_2048 || track_type == TrackType::MODE2_2048;
+}
+
+
+export bool track_type_is_data(TrackType track_type)
+{
+    return track_type_is_data_raw(track_type) || track_type_is_data_iso(track_type);
+}
 
 
 export int32_t sample_offset_a2r(uint32_t absolute)

--- a/cd/cd_common.ixx
+++ b/cd/cd_common.ixx
@@ -603,37 +603,37 @@ export std::list<std::pair<std::string, TrackType>> cue_get_entries(const std::f
     std::string line;
     while(std::getline(fs, line))
     {
-        auto tokens(tokenize(line, " \t", "\"\""));
+        auto tokens(tokenize(line, " \t\r", "\"\""));
         if(tokens.size() == 3)
         {
-            if(tokens[0].substr(0, 4) == "FILE")
+            if(tokens[0] == "FILE")
                 entry.first = tokens[1];
-            else if(tokens[0].substr(0, 5) == "TRACK" && !entry.first.empty())
+            else if(tokens[0] == "TRACK" && !entry.first.empty())
             {
-                if(tokens[2].substr(0, 5) == "AUDIO")
+                if(tokens[2] == "AUDIO")
                     entry.second = TrackType::AUDIO;
-                else if(tokens[2].substr(0, 10) == "MODE1/2352")
+                else if(tokens[2] == "MODE1/2352")
                     entry.second = TrackType::MODE1_2352;
-                else if(tokens[2].substr(0, 10) == "MODE2/2352")
+                else if(tokens[2] == "MODE2/2352")
                     entry.second = TrackType::MODE2_2352;
-                else if(tokens[2].substr(0, 8) == "CDI/2352")
+                else if(tokens[2] == "CDI/2352")
                     entry.second = TrackType::CDI_2352;
-                else if(tokens[2].substr(0, 10) == "MODE1/2048")
+                else if(tokens[2] == "MODE1/2048")
                     entry.second = TrackType::MODE1_2048;
-                else if(tokens[2].substr(0, 10) == "MODE2/2336")
+                else if(tokens[2] == "MODE2/2336")
                     entry.second = TrackType::MODE2_2336;
-                else if(tokens[2].substr(0, 8) == "CDI/2336")
+                else if(tokens[2] == "CDI/2336")
                     entry.second = TrackType::CDI_2336;
-                else if(tokens[2].substr(0, 3) == "CDG")
+                else if(tokens[2] == "CDG")
                     entry.second = TrackType::CDG;
-                else if(tokens[2].substr(0, 10) == "MODE0/2352")
+                else if(tokens[2] == "MODE0/2352")
                     entry.second = TrackType::MODE0_2352;
-                else if(tokens[2].substr(0, 10) == "MODE2/2048")
+                else if(tokens[2] == "MODE2/2048")
                     entry.second = TrackType::MODE2_2048;
-                else if(tokens[2].substr(0, 10) == "MODE2/2324")
+                else if(tokens[2] == "MODE2/2324")
                     entry.second = TrackType::MODE2_2324;
                 else
-                    entry.second = TrackType::AUDIO;
+                    entry.second = TrackType::ISO;
                 entries.push_back(entry);
                 entry.first.clear();
             }

--- a/cd/fix_msf.ixx
+++ b/cd/fix_msf.ixx
@@ -124,7 +124,7 @@ export int redumper_fix_msf(Context &ctx, Options &options)
     std::list<std::filesystem::path> tracks;
     if(std::filesystem::exists(image_prefix + ".cue"))
         for(auto const &t : cue_get_entries(image_prefix + ".cue"))
-            if(t.second)
+            if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352)
                 tracks.push_back(std::filesystem::path(options.image_path) / t.first);
 
     if(tracks.empty())

--- a/cd/fix_msf.ixx
+++ b/cd/fix_msf.ixx
@@ -124,7 +124,7 @@ export int redumper_fix_msf(Context &ctx, Options &options)
     std::list<std::filesystem::path> tracks;
     if(std::filesystem::exists(image_prefix + ".cue"))
         for(auto const &t : cue_get_entries(image_prefix + ".cue"))
-            if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352 || t.second == TrackType::MODE0_2352)
+            if(track_type_is_data_raw(t.second))
                 tracks.push_back(std::filesystem::path(options.image_path) / t.first);
 
     if(tracks.empty())

--- a/cd/fix_msf.ixx
+++ b/cd/fix_msf.ixx
@@ -124,7 +124,7 @@ export int redumper_fix_msf(Context &ctx, Options &options)
     std::list<std::filesystem::path> tracks;
     if(std::filesystem::exists(image_prefix + ".cue"))
         for(auto const &t : cue_get_entries(image_prefix + ".cue"))
-            if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352)
+            if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352 || t.second == TrackType::MODE0_2352)
                 tracks.push_back(std::filesystem::path(options.image_path) / t.first);
 
     if(tracks.empty())

--- a/filesystem/iso9660/iso9660_defs.ixx
+++ b/filesystem/iso9660/iso9660_defs.ixx
@@ -300,7 +300,14 @@ std::string split_identifier(uint32_t &version, std::string identifier)
 {
     auto s = identifier.find_last_of((char)iso9660::Characters::SEPARATOR2);
 
-    version = (s == std::string::npos ? 0 : str_to_int(identifier.substr(s + 1)));
+    if(s == std::string::npos || s + 1 >= identifier.size())
+        version = 0;
+    else
+    {
+        auto version = str_to_int64(identifier.substr(s + 1));
+        if(!version)
+            version = 0;
+    }
 
     return identifier.substr(0, s);
 }

--- a/filesystem/iso9660/iso9660_defs.ixx
+++ b/filesystem/iso9660/iso9660_defs.ixx
@@ -300,12 +300,12 @@ std::string split_identifier(uint32_t &version, std::string identifier)
 {
     auto s = identifier.find_last_of((char)iso9660::Characters::SEPARATOR2);
 
-    if(s == std::string::npos || s + 1 >= identifier.size())
+    if(s == std::string::npos)
         version = 0;
     else
     {
-        auto version = str_to_int64(identifier.substr(s + 1));
-        if(!version)
+        auto v = str_to_int64(identifier.substr(s + 1));
+        if(!v)
             version = 0;
     }
 

--- a/filesystem/iso9660/iso9660_map.ixx
+++ b/filesystem/iso9660/iso9660_map.ixx
@@ -175,7 +175,7 @@ std::vector<Area> area_map(SectorReader *sector_reader, uint32_t base_offset, ui
                     if(it != area_map.end())
                     {
                         Area new_area = Area{ o, Area::Type::FILE_EXTENT, dr.second.data_length.lsb, (name == "/" ? "" : name) + "/" + dr_name };
-                        if(new_area.size > it->first.size)
+                        if(new_area.size > it->second.size)
                             it->second = new_area;
                     }
                     else

--- a/filesystem/iso9660/iso9660_map.ixx
+++ b/filesystem/iso9660/iso9660_map.ixx
@@ -175,7 +175,7 @@ std::vector<Area> area_map(SectorReader *sector_reader, uint32_t base_offset, ui
                     if(it != area_map.end())
                     {
                         Area new_area = Area{ o, Area::Type::FILE_EXTENT, dr.second.data_length.lsb, (name == "/" ? "" : name) + "/" + dr_name };
-                        if(new_area.size > 0)
+                        if(new_area.size > it->first.size)
                             it->second = new_area;
                     }
                     else

--- a/info.ixx
+++ b/info.ixx
@@ -56,7 +56,7 @@ export int redumper_info(Context &ctx, Options &options)
         std::shared_ptr<SectorReader> raw_reader;
         std::shared_ptr<SectorReader> form1_reader;
 
-        if(t.second == TrackType::ISO)
+        if(t.second == TrackType::ISO || t.second == TrackType::MODE1_2048 || t.second == MODE2_2048)
             form1_reader = std::make_shared<Image_ISO_Reader>(t.first);
         else if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352 || t.second == TrackType::MODE0_2352)
         {

--- a/info.ixx
+++ b/info.ixx
@@ -58,7 +58,7 @@ export int redumper_info(Context &ctx, Options &options)
 
         if(t.second == TrackType::ISO)
             form1_reader = std::make_shared<Image_ISO_Reader>(t.first);
-        else if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352)
+        else if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352 || t.second == TrackType::MODE0_2352)
         {
             raw_reader = std::make_shared<Image_RawReader>(t.first);
             form1_reader = std::make_shared<Image_BIN_Form1Reader>(t.first);

--- a/info.ixx
+++ b/info.ixx
@@ -45,7 +45,7 @@ export int redumper_info(Context &ctx, Options &options)
     }
     else if(std::filesystem::exists(image_prefix + ".iso"))
     {
-        tracks.emplace_back(image_prefix + ".iso", TrackType::ISO);
+        tracks.emplace_back(image_prefix + ".iso", TrackType::MODE1_2048);
     }
     else
         throw_line("image file not found");
@@ -56,9 +56,9 @@ export int redumper_info(Context &ctx, Options &options)
         std::shared_ptr<SectorReader> raw_reader;
         std::shared_ptr<SectorReader> form1_reader;
 
-        if(t.second == TrackType::ISO || t.second == TrackType::MODE1_2048 || t.second == TrackType::MODE2_2048)
+        if(track_type_is_data_iso(t.second))
             form1_reader = std::make_shared<Image_ISO_Reader>(t.first);
-        else if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352 || t.second == TrackType::MODE0_2352)
+        else if(track_type_is_data_raw(t.second))
         {
             raw_reader = std::make_shared<Image_RawReader>(t.first);
             form1_reader = std::make_shared<Image_BIN_Form1Reader>(t.first);

--- a/info.ixx
+++ b/info.ixx
@@ -56,7 +56,7 @@ export int redumper_info(Context &ctx, Options &options)
         std::shared_ptr<SectorReader> raw_reader;
         std::shared_ptr<SectorReader> form1_reader;
 
-        if(t.second == TrackType::ISO || t.second == TrackType::MODE1_2048 || t.second == MODE2_2048)
+        if(t.second == TrackType::ISO || t.second == TrackType::MODE1_2048 || t.second == TrackType::MODE2_2048)
             form1_reader = std::make_shared<Image_ISO_Reader>(t.first);
         else if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352 || t.second == TrackType::MODE0_2352)
         {

--- a/info.ixx
+++ b/info.ixx
@@ -31,14 +31,6 @@ import utils.strings;
 namespace gpsxre
 {
 
-enum class TrackType
-{
-    DATA,
-    AUDIO,
-    ISO
-};
-
-
 export int redumper_info(Context &ctx, Options &options)
 {
     int exit_code = 0;
@@ -49,7 +41,7 @@ export int redumper_info(Context &ctx, Options &options)
     if(std::filesystem::exists(image_prefix + ".cue"))
     {
         for(auto const &t : cue_get_entries(image_prefix + ".cue"))
-            tracks.emplace_back(std::filesystem::path(options.image_path) / t.first, t.second ? TrackType::DATA : TrackType::AUDIO);
+            tracks.emplace_back(std::filesystem::path(options.image_path) / t.first, t.second);
     }
     else if(std::filesystem::exists(image_prefix + ".iso"))
     {
@@ -66,7 +58,7 @@ export int redumper_info(Context &ctx, Options &options)
 
         if(t.second == TrackType::ISO)
             form1_reader = std::make_shared<Image_ISO_Reader>(t.first);
-        else if(t.second == TrackType::DATA)
+        else if(t.second == TrackType::MODE1_2352 || t.second == TrackType::MODE2_2352 || t.second == TrackType::CDI_2352)
         {
             raw_reader = std::make_shared<Image_RawReader>(t.first);
             form1_reader = std::make_shared<Image_BIN_Form1Reader>(t.first);

--- a/skeleton.ixx
+++ b/skeleton.ixx
@@ -53,59 +53,6 @@ bool inside_contents(const std::vector<ContentEntry> &contents, uint32_t value)
 }
 
 
-bool sector_is_empty(uint8_t *s, bool iso)
-{
-    if(iso)
-        return std::all_of(s, s + FORM1_DATA_SIZE, [](uint8_t byte) { return byte == 0x00; });
-    else
-    {
-        auto sector = (Sector *)s;
-
-        if(sector->header.mode == 1)
-            return std::all_of(sector->mode1.user_data.begin(), sector->mode1.user_data.end(), [](uint8_t byte) { return byte == 0x00; });
-        else if(sector->header.mode == 2)
-        {
-            if(sector->mode2.xa.sub_header.submode & (uint8_t)CDXAMode::FORM2)
-                return std::all_of(sector->mode2.xa.form2.user_data.begin(), sector->mode2.xa.form2.user_data.end(), [](uint8_t byte) { return byte == 0x00; });
-            else
-                return std::all_of(sector->mode2.xa.form1.user_data.begin(), sector->mode2.xa.form1.user_data.end(), [](uint8_t byte) { return byte == 0x00; });
-        }
-    }
-}
-
-
-void erase_sector(uint8_t *s, bool iso)
-{
-    if(iso)
-        memset(s, 0x00, FORM1_DATA_SIZE);
-    else
-    {
-        auto sector = (Sector *)s;
-
-        if(sector->header.mode == 1)
-        {
-            memset(sector->mode1.user_data, 0x00, FORM1_DATA_SIZE);
-            memset(&sector->mode1.ecc, 0x00, sizeof(Sector::ECC));
-            sector->mode1.edc = 0;
-        }
-        else if(sector->header.mode == 2)
-        {
-            if(sector->mode2.xa.sub_header.submode & (uint8_t)CDXAMode::FORM2)
-            {
-                memset(sector->mode2.xa.form2.user_data, 0x00, FORM2_DATA_SIZE);
-                sector->mode2.xa.form2.edc = 0;
-            }
-            else
-            {
-                memset(sector->mode2.xa.form1.user_data, 0x00, FORM1_DATA_SIZE);
-                memset(&sector->mode2.xa.form1.ecc, 0x00, sizeof(Sector::ECC));
-                sector->mode2.xa.form1.edc = 0;
-            }
-        }
-    }
-}
-
-
 void skeleton(const std::string &image_prefix, const std::string &image_path, bool iso, Options &options)
 {
     std::filesystem::path skeleton_path(image_prefix + ".skeleton");
@@ -152,9 +99,6 @@ void skeleton(const std::string &image_prefix, const std::string &image_path, bo
         if(gap_start < area_map[i + 1].offset)
         {
             uint32_t gap_size = area_map[i + 1].offset - gap_start;
-
-            while(sector_is_empty(sector_reader->read(), iso) && gap_start < area_map[i + 1].offset)
-                gap_start++;
 
             // 5% or more in relation to the total filesystem size
             if((uint64_t)gap_size * 100 / sectors_count > 5)

--- a/skeleton.ixx
+++ b/skeleton.ixx
@@ -203,20 +203,12 @@ export int redumper_skeleton(Context &ctx, Options &options)
         for(auto const &t : cue_get_entries(image_prefix + ".cue"))
         {
             // skip audio tracks
-            if(t.second == TrackType::AUDIO || t.second == TrackType::CDG)
+            if(!track_type_is_data(t.second))
                 continue;
-
-            // skip unsupported sector sizes
-            if(t.second == TrackType::MODE2_2336 || t.second == TrackType::CDI_2336 || t.second == TrackType::MODE2_2324)
-                continue;
-
-            bool iso = false;
-            if(t.second == TrackType::ISO || t.second == TrackType::MODE1_2048 || t.second == TrackType::MODE2_2048)
-                iso = true;
 
             auto track_prefix = (std::filesystem::path(options.image_path) / std::filesystem::path(t.first).stem()).string();
 
-            skeleton(track_prefix, (std::filesystem::path(options.image_path) / t.first).string(), iso, options);
+            skeleton(track_prefix, (std::filesystem::path(options.image_path) / t.first).string(), track_type_is_data_iso(t.second), options);
         }
     }
     else if(std::filesystem::exists(image_prefix + ".iso"))

--- a/skeleton.ixx
+++ b/skeleton.ixx
@@ -131,10 +131,9 @@ void skeleton(const std::string &image_prefix, const std::string &image_path, bo
         if(gap_start < area_map[i + 1].offset)
         {
             uint32_t gap_size = area_map[i + 1].offset - gap_start;
-            uint32_t gap_sectors = gap_size / (iso ? FORM1_DATA_SIZE : CD_DATA_SIZE);
 
             // >2048 sectors or >5% or more in relation to the total filesystem size
-            if(gap_sectors > 2048 || (uint64_t)gap_size * 100 / sectors_count > 5)
+            if(gap_size > 2048 || (uint64_t)gap_size * 100 / sectors_count > 5)
                 contents.emplace_back(std::format("GAP_{:07}", gap_start), gap_start, gap_size, gap_size * sector_reader->sectorSize());
         }
     }

--- a/skeleton.ixx
+++ b/skeleton.ixx
@@ -202,13 +202,21 @@ export int redumper_skeleton(Context &ctx, Options &options)
     {
         for(auto const &t : cue_get_entries(image_prefix + ".cue"))
         {
-            // only support MODE1/MODE2 CD-ROM dumps
-            if(t.second != TrackType::MODE1_2352 && t.second != TrackType::MODE2_2352)
+            // skip audio tracks
+            if(t.second == TrackType::AUDIO || t.second == TrackType::CDG)
                 continue;
+
+            // skip unsupported sector sizes
+            if(t.second == TrackType::MODE2_2336 || t.second == TrackType::CDI_2336 || t.second == TrackType::MODE2_2324)
+                continue;
+
+            bool iso = false;
+            if(t.second == TrackType::ISO || t.second == TrackType::MODE1_2048 || t.second == TrackType::MODE2_2048)
+                iso = true;
 
             auto track_prefix = (std::filesystem::path(options.image_path) / std::filesystem::path(t.first).stem()).string();
 
-            skeleton(track_prefix, (std::filesystem::path(options.image_path) / t.first).string(), false, options);
+            skeleton(track_prefix, (std::filesystem::path(options.image_path) / t.first).string(), iso, options);
         }
     }
     else if(std::filesystem::exists(image_prefix + ".iso"))

--- a/skeleton.ixx
+++ b/skeleton.ixx
@@ -53,6 +53,27 @@ bool inside_contents(const std::vector<ContentEntry> &contents, uint32_t value)
 }
 
 
+bool sector_is_empty(uint8_t *s, bool iso)
+{
+    if(iso)
+        return std::all_of(s, s + FORM1_DATA_SIZE, [](uint8_t byte) { return byte == 0x00; });
+    else
+    {
+        auto sector = (Sector *)s;
+
+        if(sector->header.mode == 1)
+            return std::all_of(sector->mode1.user_data.begin(), sector->mode1.user_data.end(), [](uint8_t byte) { return byte == 0x00; });
+        else if(sector->header.mode == 2)
+        {
+            if(sector->mode2.xa.sub_header.submode & (uint8_t)CDXAMode::FORM2)
+                return std::all_of(sector->mode2.xa.form2.user_data.begin(), sector->mode2.xa.form2.user_data.end(), [](uint8_t byte) { return byte == 0x00; });
+            else
+                return std::all_of(sector->mode2.xa.form1.user_data.begin(), sector->mode2.xa.form1.user_data.end(), [](uint8_t byte) { return byte == 0x00; });
+        }
+    }
+}
+
+
 void erase_sector(uint8_t *s, bool iso)
 {
     if(iso)
@@ -132,8 +153,11 @@ void skeleton(const std::string &image_prefix, const std::string &image_path, bo
         {
             uint32_t gap_size = area_map[i + 1].offset - gap_start;
 
-            // >2048 sectors or >5% or more in relation to the total filesystem size
-            if(gap_size > 2048 || (uint64_t)gap_size * 100 / sectors_count > 5)
+            while(sector_is_empty(sector_reader->read(), iso) && gap_start < area_map[i + 1].offset)
+                gap_start++;
+
+            // 5% or more in relation to the total filesystem size
+            if((uint64_t)gap_size * 100 / sectors_count > 5)
                 contents.emplace_back(std::format("GAP_{:07}", gap_start), gap_start, gap_size, gap_size * sector_reader->sectorSize());
         }
     }

--- a/skeleton.ixx
+++ b/skeleton.ixx
@@ -53,6 +53,38 @@ bool inside_contents(const std::vector<ContentEntry> &contents, uint32_t value)
 }
 
 
+void erase_sector(uint8_t *s, bool iso)
+{
+    if(iso)
+        memset(s, 0x00, FORM1_DATA_SIZE);
+    else
+    {
+        auto sector = (Sector *)s;
+
+        if(sector->header.mode == 1)
+        {
+            memset(sector->mode1.user_data, 0x00, FORM1_DATA_SIZE);
+            memset(&sector->mode1.ecc, 0x00, sizeof(Sector::ECC));
+            sector->mode1.edc = 0;
+        }
+        else if(sector->header.mode == 2)
+        {
+            if(sector->mode2.xa.sub_header.submode & (uint8_t)CDXAMode::FORM2)
+            {
+                memset(sector->mode2.xa.form2.user_data, 0x00, FORM2_DATA_SIZE);
+                sector->mode2.xa.form2.edc = 0;
+            }
+            else
+            {
+                memset(sector->mode2.xa.form1.user_data, 0x00, FORM1_DATA_SIZE);
+                memset(&sector->mode2.xa.form1.ecc, 0x00, sizeof(Sector::ECC));
+                sector->mode2.xa.form1.edc = 0;
+            }
+        }
+    }
+}
+
+
 void skeleton(const std::string &image_prefix, const std::string &image_path, bool iso, Options &options)
 {
     std::filesystem::path skeleton_path(image_prefix + ".skeleton");


### PR DESCRIPTION
- Read track type from CUE and allow 0-valued sector size in PVD Fixes #124
- Ignores str_to_int errors and falls back to identifier version 0 (for Romeo filesystems, UTF-16 encoded strings, and other identifiers that break ISO9660 spec). Fixes #149
- If Parent Record Number is 0 or some large number, assume it is in the root folder. Fixes #213 and Fixes #123
- Don't replace an Area in the Area map if the Area size is smaller. Fixes #111 