### PR TITLE
Add kreon partial ss option

### DIFF
--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -448,9 +448,9 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, DumpMode dum
             std::vector<uint8_t> security_sector(FORM1_DATA_SIZE);
             std::vector<uint8_t> ss_leadout(FORM1_DATA_SIZE);
 
-            bool complete_ss = xbox_get_security_sector(*ctx.sptd, security_sector);
+            bool complete_ss = xbox_get_security_sector(*ctx.sptd, security_sector, options.kreon_partial_ss);
             if(!complete_ss)
-                LOG("warning: could not get complete security sector, attempting to continue");
+                LOG("warning: could not get complete security sector");
 
             // validate security sector
             XGD_Type xgd_type = get_xgd_type((READ_DVD_STRUCTURE_LayerDescriptor &)security_sector[0]);

--- a/options.ixx
+++ b/options.ixx
@@ -59,6 +59,7 @@ export struct Options
     bool plextor_leadin_force_store;
     bool asus_skip_leadout;
     int asus_leadout_retries;
+    bool kreon_partial_ss;
     bool disable_cdtext;
     bool correct_offset_shift;
     bool offset_shift_relocate;
@@ -99,6 +100,7 @@ export struct Options
         , plextor_leadin_force_store(false)
         , asus_skip_leadout(false)
         , asus_leadout_retries(32)
+        , kreon_partial_ss(false)
         , disable_cdtext(false)
         , correct_offset_shift(false)
         , offset_shift_relocate(false)
@@ -249,6 +251,8 @@ export struct Options
                         asus_skip_leadout = true;
                     else if(key == "--asus-leadout-retries")
                         i_value = &asus_leadout_retries;
+                    else if(key == "--kreon-partial-ss")
+                        kreon_partial_ss = true;
                     else if(key == "--disable-cdtext")
                         disable_cdtext = true;
                     else if(key == "--correct-offset-shift")
@@ -375,6 +379,7 @@ export struct Options
         LOG("\t--plextor-skip-leadin           \tskip dumping lead-in using negative range");
         LOG("\t--plextor-leadin-retries=VALUE  \tmaximum number of lead-in retries per session (default: {})", plextor_leadin_retries);
         LOG("\t--plextor-leadin-force-store    \tstore unverified lead-in");
+        LOG("\t--kreon-partial-ss              \tget minimal security sector (fixes bad firmware)");
 
         LOG("\t--asus-skip-leadout             \tskip extracting lead-out from drive cache");
         LOG("\t--asus-leadout-retries          \tnumber of preceding lead-out sector reads to fill up the cache (default: {})", asus_leadout_retries);

--- a/utils/xbox.ixx
+++ b/utils/xbox.ixx
@@ -230,7 +230,7 @@ export void clean_xbox_security_sector(std::vector<uint8_t> &security_sector)
     }
 }
 
-export bool xbox_get_security_sector(SPTD &sptd, std::vector<uint8_t> &response_data)
+export bool xbox_get_security_sector(SPTD &sptd, std::vector<uint8_t> &response_data, bool kreon_partial_ss)
 {
     SPTD::Status status;
 
@@ -244,6 +244,10 @@ export bool xbox_get_security_sector(SPTD &sptd, std::vector<uint8_t> &response_
             if(i == 0)
                 throw_line("failed to get security sector, SCSI ({})", SPTD::StatusMessage(status));
 
+            return false;
+        }
+        else if (kreon_partial_ss)
+        {
             return false;
         }
     }

--- a/utils/xbox.ixx
+++ b/utils/xbox.ixx
@@ -246,7 +246,7 @@ export bool xbox_get_security_sector(SPTD &sptd, std::vector<uint8_t> &response_
 
             return false;
         }
-        else if (kreon_partial_ss)
+        else if(kreon_partial_ss)
         {
             return false;
         }


### PR DESCRIPTION
Adds a `--kreon-partial-ss` option that does not attempt to perform the full SS functionality for Xbox 360 dumps.
This will always produce 'bad' SS files, however it prevents buggy Kreon firmware from erroring during dumps.
In particular this fixes an issue with some 353B/163B drives locking up completely and not responding until repowering the drive.