### PR TITLE
fix

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: linux_${{matrix.os}}_${{matrix.arch}}
+        name: linux_${{matrix.arch}}
         path: ${{github.workspace}}/BUILD/redumper-*.zip
         
   build-macos:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,17 +34,23 @@ jobs:
     needs: check
     strategy:
       matrix:
-        arch: [Win32, x64, ARM64]
+        include:
+          - arch: x86
+            platform: Win32
+          - arch: x64
+            platform: x64
+          - arch: arm64
+            platform: ARM64
     runs-on: windows-2022
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: CMake Configure
-      run: cmake -B ${{github.workspace}}/BUILD -G "Visual Studio 17 2022" -A ${{matrix.arch}} -DCMAKE_BUILD_TYPE=Release -DREDUMPER_VERSION_BUILD=${{needs.check.outputs.build_number}}
+      run: cmake -B ${{github.workspace}}/BUILD -G "Visual Studio 17 2022" -A ${{matrix.platform}} -DCMAKE_BUILD_TYPE=Release -DREDUMPER_VERSION_BUILD=${{needs.check.outputs.build_number}} -DREDUMPER_OS=windows -DREDUMPER_ARCH=${{matrix.arch}}
     - name: CMake Build
       run: cmake --build ${{github.workspace}}/BUILD --config Release
     - name: CTest
-      if: ${{ matrix.arch != 'ARM64' }}
+      if: ${{ matrix.arch != 'arm64' }}
       working-directory: ${{github.workspace}}/BUILD
       run: ctest -C Release
     - name: CPack
@@ -82,10 +88,10 @@ jobs:
       uses: actions/checkout@v4
     - name: CMake Configure
       if: ${{ matrix.arch == 'x86' }}
-      run: CXX=clang++-18 CXXFLAGS="-target i686-linux-gnu" cmake -B ${{github.workspace}}/BUILD -G "Ninja" -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DREDUMPER_CLANG_LINK_OPTIONS="-static" -DCMAKE_BUILD_TYPE=Release -DREDUMPER_VERSION_BUILD=${{needs.check.outputs.build_number}}
+      run: CXX=clang++-18 CXXFLAGS="-target i686-linux-gnu" cmake -B ${{github.workspace}}/BUILD -G "Ninja" -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DREDUMPER_CLANG_LINK_OPTIONS="-static" -DCMAKE_BUILD_TYPE=Release -DREDUMPER_VERSION_BUILD=${{needs.check.outputs.build_number}} -DREDUMPER_OS=linux -DREDUMPER_ARCH=${{matrix.arch}}
     - name: CMake Configure
       if: ${{ matrix.arch != 'x86' }}
-      run: CXX=clang++-18 cmake -B ${{github.workspace}}/BUILD -G "Ninja" -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DREDUMPER_CLANG_LINK_OPTIONS="-static" -DCMAKE_BUILD_TYPE=Release -DREDUMPER_VERSION_BUILD=${{needs.check.outputs.build_number}}
+      run: CXX=clang++-18 cmake -B ${{github.workspace}}/BUILD -G "Ninja" -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DREDUMPER_CLANG_LINK_OPTIONS="-static" -DCMAKE_BUILD_TYPE=Release -DREDUMPER_VERSION_BUILD=${{needs.check.outputs.build_number}} -DREDUMPER_OS=linux -DREDUMPER_ARCH=${{matrix.arch}}
     - name: CMake Build
       run: cmake --build ${{github.workspace}}/BUILD --config Release
     - name: CTest
@@ -110,7 +116,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: CMake Configure
-      run: CXX=$(brew --prefix llvm@18)/bin/clang++ cmake -B ${{github.workspace}}/BUILD -G "Ninja" -DREDUMPER_CLANG_USE_LIBCPP=ON -DREDUMPER_CLANG_LINK_OPTIONS="-L$(brew --prefix llvm@18)/lib/c++" -DCMAKE_BUILD_TYPE=Release -DREDUMPER_VERSION_BUILD=${{needs.check.outputs.build_number}}
+      run: CXX=$(brew --prefix llvm@18)/bin/clang++ cmake -B ${{github.workspace}}/BUILD -G "Ninja" -DREDUMPER_CLANG_USE_LIBCPP=ON -DREDUMPER_CLANG_LINK_OPTIONS="-L$(brew --prefix llvm@18)/lib/c++" -DCMAKE_BUILD_TYPE=Release -DREDUMPER_VERSION_BUILD=${{needs.check.outputs.build_number}} -DREDUMPER_OS=macos -DREDUMPER_ARCH=arm64
     - name: CMake Build
       run: cmake --build ${{github.workspace}}/BUILD --config Release
     - name: CTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ else()
     message(FATAL_ERROR "Unknown target platform")
 endif()
 
+message(STATUS "*** CPU: ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "*** POINTER: ${CMAKE_SIZEOF_VOID_P}")
+
 # architecture
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
     set(REDUMPER_ARCH "x64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,39 +14,24 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 set(CMAKE_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE} CACHE INTERNAL "Active configuration" FORCE)
 
-# operating system
+# target operating system, it's assumed that it's the same as the host operating system
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(REDUMPER_TARGET_LINUX 1)
-    set(REDUMPER_OS "linux")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(REDUMPER_TARGET_WINDOWS 1)
-    set(REDUMPER_OS "windows")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(REDUMPER_TARGET_MACOSX 1)
-    set(REDUMPER_OS "macos")
-else()
-    message(FATAL_ERROR "Unknown target platform")
-endif()
-
-message(STATUS "*** CPU: ${CMAKE_SYSTEM_PROCESSOR}")
-message(STATUS "*** POINTER: ${CMAKE_SIZEOF_VOID_P}")
-
-# architecture
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
-    set(REDUMPER_ARCH "x64")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i386|i686|x86)$")
-    set(REDUMPER_ARCH "x86")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
-    set(REDUMPER_ARCH "arm64")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7|armhf)$")
-    set(REDUMPER_ARCH "armhf")
-else()
-    set(REDUMPER_ARCH ${CMAKE_SYSTEM_PROCESSOR})
+    set(REDUMPER_TARGET_MACOS 1)
 endif()
 
 # packaging
+set(REDUMPER_OS "" CACHE STRING "Target operating system")
+set(REDUMPER_ARCH "" CACHE STRING "Target architecture")
 set(CPACK_GENERATOR "ZIP")
-set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${REDUMPER_VERSION_BUILD}-${REDUMPER_OS}-${REDUMPER_ARCH}")
+if(REDUMPER_VERSION_BUILD STREQUAL "LOCAL")
+    set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${REDUMPER_VERSION_BUILD}")
+else()
+    set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${REDUMPER_VERSION_BUILD}-${REDUMPER_OS}-${REDUMPER_ARCH}")
+endif()
 include(CPack)
 
 # C/C++
@@ -219,7 +204,7 @@ target_include_directories(redumper
 set(libs
 )
 
-if(REDUMPER_TARGET_MACOSX)
+if(REDUMPER_TARGET_MACOS)
     find_library(CORE_FOUNDATION CoreFoundation REQUIRED)
     find_library(IO_KIT IOKit REQUIRED)
     set(libs ${libs}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/build now accept explicit OS and architecture settings, allowing configurable platform-specific builds.

* **Packaging**
  * Package filenames include OS/architecture for non-LOCAL builds; LOCAL builds continue to omit OS/architecture.

* **Chores (macOS)**
  * macOS build logic updated and macOS-specific library linkage preserved (no user-facing behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->