### PR TITLE
new drive added

### DIFF
--- a/drive.ixx
+++ b/drive.ixx
@@ -167,6 +167,7 @@ static const std::vector<DriveConfig> DRIVE_DATABASE =
     { "ATAPI"   , "iHBS312 2"        , "PL17", "2012/10/31 13:50"   ,   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::LG_ASU8A }, // olofolleola4
     { "HL-DT-ST", "BD-RE WH14NS40"   , "1.03", "N0A09A0K9HF6ND5914" ,   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::LG_ASU8C }, // Lugamo
     { "hp",       "BD-RE BH40N"      , "B7C6", "P100800336CF002420" ,   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::LG_ASU8C }, // TonyLizard
+    { "HL-DT-ST", "BD-RE BH16NS40"   , "1.03", "N0A03A0K9JF41A3139" ,   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::LG_ASU8C }, // breversa
     // PATCHED
     { "ASUS"    , "BW-16D1HT"        , "3.10", "WM01601KLZL4TG5625" ,   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // 3.10MK or RibShark FW definition
     { "TSSTcorp", "DVD-ROM TS-H353C" , "ZZ00", ""                   ,   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // MoriGM


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HL-DT-ST BD-RE BH16NS40 (revision 1.03) drive model. The drive is now properly recognized and configured for optimal compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->