### PR TITLE
SCSI timeout option

### DIFF
--- a/debug.ixx
+++ b/debug.ixx
@@ -152,7 +152,7 @@ export int redumper_debug(Context &ctx, Options &options)
         {
             try
             {
-                SPTD sptd(d);
+                SPTD sptd(d, options.scsi_timeout);
 
                 auto status = cmd_drive_ready(sptd);
                 if(!status.status_code)
@@ -297,7 +297,7 @@ export int redumper_debug(Context &ctx, Options &options)
     // MEDIATEK cache read
     if(0)
     {
-        SPTD sptd(options.drive);
+        SPTD sptd(options.drive, options.scsi_timeout);
         std::vector<uint8_t> cache;
         SPTD::Status status = mediatek_cache_read(sptd, cache, 1024 * 1024 * mediatek_get_config(Type::MTK3).size_mb);
 

--- a/options.ixx
+++ b/options.ixx
@@ -79,6 +79,7 @@ export struct Options
     bool drive_test_skip_cache_read;
     bool skip_subcode_desync;
     int cdr_error_threshold;
+    int scsi_timeout;
 
 
     Options(int argc, const char *argv[])
@@ -120,6 +121,7 @@ export struct Options
         , drive_test_skip_cache_read(false)
         , skip_subcode_desync(false)
         , cdr_error_threshold(16)
+        , scsi_timeout(50000)
     {
         for(int i = 1; i < argc; ++i)
             arguments += str_quoted_if_space(argv[i]) + " ";
@@ -302,6 +304,8 @@ export struct Options
                         skip_subcode_desync = true;
                     else if(key == "--cdr-error-threshold")
                         i_value = &cdr_error_threshold;
+                    else if(key == "--scsi-timeout")
+                        i_value = &scsi_timeout;
                     // unknown option
                     else
                     {
@@ -441,6 +445,7 @@ export struct Options
         LOG("\t--force-flash                   \tskip drive vendor/model verification when flashing firmware (WARNING: can brick your drive)");
         LOG("\t--skip-subcode-desync           \tskip storing sectors with mismatching subcode Q absolute MSF");
         LOG("\t--cdr-error-threshold=VALUE     \tmaximum number of trailing C2 errors allowed on a CD-R (default: {})", cdr_error_threshold);
+        LOG("\t--scsi-timeout=VALUE            \tSCSI command timeout, milliseconds (default: {})", scsi_timeout);
     }
 };
 

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -304,7 +304,7 @@ std::list<std::pair<std::string, Command>> redumper_disc_get_commands(Options &o
 }
 
 
-std::string first_ready_drive()
+std::string first_ready_drive(const Options &options)
 {
     std::string drive;
 
@@ -312,7 +312,7 @@ std::string first_ready_drive()
     {
         try
         {
-            SPTD sptd(d);
+            SPTD sptd(d, options.scsi_timeout);
 
             auto status = cmd_drive_ready(sptd);
             if(!status.status_code)
@@ -384,7 +384,7 @@ export int redumper(Options &options)
         {
             if(aggregate.drive_autoselect)
             {
-                options.drive = first_ready_drive();
+                options.drive = first_ready_drive(options);
 
                 if(options.drive.empty())
                     throw_line("no ready drives detected on the system");
@@ -393,7 +393,7 @@ export int redumper(Options &options)
                 throw_line("drive is not provided");
         }
 
-        ctx.sptd = std::make_shared<SPTD>(options.drive);
+        ctx.sptd = std::make_shared<SPTD>(options.drive, options.scsi_timeout);
 
         if(aggregate.drive_ready)
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--scsi-timeout` command-line option to configure timeout duration for SCSI device communication (default: 50000ms)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->