### PR TITLE
Skip all sectors after a subcode desync instead of just the first

### DIFF
--- a/cd/cd_dump.ixx
+++ b/cd/cd_dump.ixx
@@ -132,12 +132,12 @@ bool check_subcode_shift(int32_t &subcode_shift, int32_t lba, std::span<const ui
 
                 if(options.verbose)
                     LOG_R("[LBA: {:6}] subcode desync (shift: {:+})", lba, subcode_shift);
-
-                if(subcode_shift && options.skip_subcode_desync)
-                    skip = true;
             }
         }
     }
+
+    if(subcode_shift && options.skip_subcode_desync)
+        skip = true;
 
     return skip;
 }


### PR DESCRIPTION
The original function would only skip one sector after a subcode desync. The intent is to skip all sectors untl the desync ends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal logic improvements to subcode shift handling for better code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->