### PR TITLE
reverted to --rings option, removed desync stats

### DIFF
--- a/cd/cd_common.ixx
+++ b/cd/cd_common.ixx
@@ -251,10 +251,6 @@ export void subcode_load_subpq(std::vector<ChannelP> &subp, std::vector<ChannelQ
 
     if(!desync_stats.empty() && !(desync_stats.size() == 1 && !desync_stats.begin()->first))
     {
-        LOG("subcode desync statistics: ");
-        for(auto const &e : desync_stats)
-            LOG("  shift: {:+}, count: {}", e.first, e.second);
-
         if(auto it = std::max_element(desync_stats.begin(), desync_stats.end(), [](auto a, auto b) { return a.second < b.second; }); it != desync_stats.end() && it->first)
         {
             uint32_t shift_value = std::abs(it->first);

--- a/options.ixx
+++ b/options.ixx
@@ -79,6 +79,7 @@ export struct Options
     bool drive_test_skip_plextor_leadin;
     bool drive_test_skip_cache_read;
     bool skip_subcode_desync;
+    bool rings;
     int cdr_error_threshold;
     int scsi_timeout;
 
@@ -122,6 +123,7 @@ export struct Options
         , drive_test_skip_plextor_leadin(false)
         , drive_test_skip_cache_read(false)
         , skip_subcode_desync(false)
+        , rings(false)
         , cdr_error_threshold(16)
         , scsi_timeout(50000)
     {
@@ -306,6 +308,8 @@ export struct Options
                         drive_test_skip_cache_read = true;
                     else if(key == "--skip-subcode-desync")
                         skip_subcode_desync = true;
+                    else if(key == "--rings")
+                        rings = true;
                     else if(key == "--cdr-error-threshold")
                         i_value = &cdr_error_threshold;
                     else if(key == "--scsi-timeout")
@@ -449,6 +453,7 @@ export struct Options
         LOG("\t--firmware=VALUE                \tfirmware filename");
         LOG("\t--force-flash                   \tskip drive vendor/model verification when flashing firmware (WARNING: can brick your drive)");
         LOG("\t--skip-subcode-desync           \tskip storing sectors with mismatching subcode Q absolute MSF");
+        LOG("\t--rings                         \tenable filesystem based rings detection");
         LOG("\t--cdr-error-threshold=VALUE     \tmaximum number of trailing C2 errors allowed on a CD-R (default: {})", cdr_error_threshold);
         LOG("\t--scsi-timeout=VALUE            \tSCSI command timeout, milliseconds (default: {})", scsi_timeout);
     }

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -269,7 +269,9 @@ std::list<std::pair<std::string, Command>> redumper_disc_get_commands(Options &o
 {
     std::list<std::pair<std::string, Command>> commands;
 
-    std::list<std::string> cd_commands{ "rings", "dump", "dump::extra", "protection", "refine", "dvdkey", "split", "hash", "info" };
+    std::list<std::string> cd_commands{ "dump", "dump::extra", "protection", "refine", "dvdkey", "split", "hash", "info" };
+    if(options.rings)
+        cd_commands.insert(cd_commands.begin(), "rings");
     if(options.auto_eject)
     {
         if(auto it = std::find(cd_commands.begin(), cd_commands.end(), "split"); it != cd_commands.end())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--rings` command-line option to enable filesystem-based rings detection. The rings command will automatically execute when this option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->