### PR TITLE
Add patched Optiarc AD-7203A

### DIFF
--- a/drive.ixx
+++ b/drive.ixx
@@ -187,6 +187,7 @@ static const std::vector<DriveConfig> DRIVE_DATABASE =
     { "Optiarc" , "DVD RW AD-5280S"  , "1.01", "seri-01 BT-LIGGY"    , "",  +48,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // seri
     { "Optiarc" , "DVD RW AD-7590A"  , "1.V1", "seri-01 BT-LIGGY"    , "",  +48,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // seri
     { "SONY"    , "DVD RW DRU-875S"  , "1.61", "seri-01 BT-LIGGY"    , "",  +48,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // seri
+    { "Optiarc" , "DVD RW AD-7203A"  , "1.09", "seri-01 BT-LIGGY"    , "",  +48,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // seri
     // PATCHED KREON
     { "TSSTcorp", "DVD-ROM SH-D163B" , "ZZ01", "KREON V1.00.........", "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // MoriGM
     { "TSSTcorp", "DVD-ROM SH-D162C" , "DC02", "KREON V1.00.........", "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_SUB_C2, Type::GENERIC  }, // MoriGM


### PR DESCRIPTION
`drive::test`:

```plain
redumper (build: b708)

arguments: drive::test
warning: drive not found in the database
warning: using generic drive

drive information
  path: /dev/sg1
  inquiry: Optiarc - DVD RW AD-7203A (revision level: 1.09, vendor specific: seri-01 BT-LIGGY)
  configuration: GENERIC (read offset: +48, C2 shift: 0, pre-gap start: +0, read method: BE, sector order: DATA_C2_SUB)
  profile: CD-ROM
  read speed: <optimal>

*** DRIVE::TEST (time check: 0s)

READ CD (BE) command (audio): yes
  DATA
  DATA_C2
  DATA_C2BEB
  DATA_C2BEB_SUB
  DATA_C2BEB_SUBQ
  DATA_C2BEB_SUBRW
  DATA_C2_SUB
  DATA_C2_SUBQ
  DATA_C2_SUBRW
  DATA_SUB
  DATA_SUBQ
  DATA_SUBRW

READ CD (BE) command (data): yes
  DATA
  DATA_C2
  DATA_C2BEB
  DATA_C2BEB_SUB
  DATA_C2BEB_SUBQ
  DATA_C2BEB_SUBRW
  DATA_C2_SUB
  DATA_C2_SUBQ
  DATA_C2_SUBRW
  DATA_SUB
  DATA_SUBQ
  DATA_SUBRW

READ CD (BE) command (scrambled): yes
  DATA
  DATA_C2
  DATA_C2BEB
  DATA_C2BEB_SUB
  DATA_C2BEB_SUBQ
  DATA_C2BEB_SUBRW
  DATA_C2_SUB
  DATA_C2_SUBQ
  DATA_C2_SUBRW
  DATA_SUB
  DATA_SUBQ
  DATA_SUBRW

READ CD MSF (B9) command (audio): yes
  DATA
  DATA_C2
  DATA_C2BEB
  DATA_C2BEB_SUB
  DATA_C2BEB_SUBQ
  DATA_C2BEB_SUBRW
  DATA_C2_SUB
  DATA_C2_SUBQ
  DATA_C2_SUBRW
  DATA_SUB
  DATA_SUBQ
  DATA_SUBRW

READ CD MSF (B9) command (data): yes
  DATA
  DATA_C2
  DATA_C2BEB
  DATA_C2BEB_SUB
  DATA_C2BEB_SUBQ
  DATA_C2BEB_SUBRW
  DATA_C2_SUB
  DATA_C2_SUBQ
  DATA_C2_SUBRW
  DATA_SUB
  DATA_SUBQ
  DATA_SUBRW

READ CD MSF (B9) command (scrambled): yes
  DATA
  DATA_C2
  DATA_C2BEB
  DATA_C2BEB_SUB
  DATA_C2BEB_SUBQ
  DATA_C2BEB_SUBRW
  DATA_C2_SUB
  DATA_C2_SUBQ
  DATA_C2_SUBRW
  DATA_SUB
  DATA_SUBQ
  DATA_SUBRW

READ CD MSF (D5) command (audio): no

READ CD MSF (D5) command (data): no

READ CD MSF (D5) command (scrambled): no

READ CDDA (D8) command (audio): no

READ CDDA (D8) command (data): no

PLEXTOR lead-in: no
lead-in/pre-gap: 135 sectors
lead-out: 100+ sectors
MEDIATEK cache read (F1): no
```

optidump repo is update and firmware is uploaded :)