### PR TITLE
fix undefined behavior

### DIFF
--- a/systems/dc.ixx
+++ b/systems/dc.ixx
@@ -159,7 +159,7 @@ private:
 
         for(uint32_t i = 0; i < version.length(); ++i)
         {
-            char ch = version[i];
+            unsigned char ch = version[i];
             if(!std::isdigit(ch) && ch != '.')
                 return "";
         }

--- a/systems/sat.ixx
+++ b/systems/sat.ixx
@@ -155,7 +155,7 @@ private:
             auto v = serialversion.substr(p + 1);
             erase_all_inplace(v, ' ');
 
-            if(std::all_of(v.begin(), v.end(), [](char c) { return std::isdigit(c) || c == '.'; }))
+            if(std::all_of(v.begin(), v.end(), [](unsigned char c) { return std::isdigit(c) || c == '.'; }))
                 version = v;
         }
 

--- a/utils/strings.ixx
+++ b/utils/strings.ixx
@@ -23,13 +23,13 @@ namespace gpsxre
 
 export void trim_left_inplace(std::string &s)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char c) { return !std::isspace(c); }));
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char c) { return !std::isspace(c); }));
 }
 
 
 export void trim_right_inplace(std::string &s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](char c) { return !std::isspace(c); }).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char c) { return !std::isspace(c); }).base(), s.end());
 }
 
 
@@ -90,7 +90,7 @@ export std::string replace_all(std::string s, const std::string &from, const std
 export std::string str_uppercase(const std::string &s)
 {
     std::string str_uc;
-    std::transform(s.begin(), s.end(), std::back_inserter(str_uc), [](char c) { return std::toupper(c); });
+    std::transform(s.begin(), s.end(), std::back_inserter(str_uc), [](unsigned char c) { return std::toupper(c); });
 
     return str_uc;
 }
@@ -158,7 +158,7 @@ export std::vector<std::string> tokenize(const std::string &str, const char *del
 
 export void replace_nonprint_inplace(std::string &s, char r)
 {
-    std::transform(s.begin(), s.end(), s.begin(), [r](char c) { return isprint(c) ? c : r; });
+    std::transform(s.begin(), s.end(), s.begin(), [r](unsigned char c) { return isprint(c) ? c : r; });
 }
 
 
@@ -191,7 +191,7 @@ export std::optional<uint64_t> str_to_uint64(std::string::const_iterator str_beg
     bool valid = false;
     for(auto it = str_begin; it != str_end; ++it)
     {
-        if(std::isdigit(*it))
+        if(std::isdigit((unsigned char)*it))
         {
             value = (value * 10) + (*it - '0');
             valid = true;


### PR DESCRIPTION
This PR fixes a few potentially undefined behaviors related to `cctype` functions.

Quote from [cppreference.com](https://en.cppreference.com/cpp/string/byte/isspace):  
> Like all other functions from <cctype>, the behavior of std::isspace is undefined if the argument's value is neither representable as unsigned char nor equal to EOF. To use these functions safely with plain chars (or signed chars), the argument should first be converted to unsigned char

It was noticed by coderabbitai [here](https://github.com/superg/redumper/pull/370#discussion_r3070072978), but also previously by @Deterous [here](https://github.com/superg/redumper/pull/147#issuecomment-2119828391).
It should thus fix #150.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved character validation logic across string processing and version extraction functions to enhance robustness when handling various character types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->