### PR TITLE
MT1959 flashing support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ target_sources(redumper
     "crc/crc.ixx"
     "crc/crc16_gsm.ixx"
     "crc/crc32.ixx"
+    "drive/flash_mt1959.ixx"
     "drive/flash_plextor.ixx"
     "drive/flash_sd616.ixx"
     "drive/flash_tsst.ixx"

--- a/drive/flash_mt1959.ixx
+++ b/drive/flash_mt1959.ixx
@@ -84,7 +84,7 @@ std::vector<uint8_t> read_mt1959_config(SPTD &sptd, uint32_t config_offset, uint
     std::vector<uint8_t> config(config_size);
 
     if(auto status = cmd_read_buffer(sptd, config.data(), config.size(), READ_BUFFER_Mode::DOWNLOAD_MICROCODE_WITH_OFFSETS, config_offset, config.size()); status.status_code)
-        throw_line("failed to read drive patch configuration");
+        throw_line("failed to read drive patch configuration, SCSI ({})", SPTD::StatusMessage(status));
 
     return config;
 }

--- a/drive/flash_mt1959.ixx
+++ b/drive/flash_mt1959.ixx
@@ -1,0 +1,99 @@
+module;
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <span>
+#include <string>
+#include <thread>
+#include <vector>
+#include "throw_line.hh"
+
+export module drive.flash.mt1959;
+
+import common;
+import options;
+import scsi.cmd;
+import scsi.mmc;
+import scsi.sptd;
+import utils.file_io;
+import utils.logger;
+
+
+
+namespace gpsxre
+{
+
+const std::vector<std::pair<std::string, std::string>> MT1959_SUPPORTED_DRIVES = {
+    // { "HL-DT-ST", "BD-RE BU40N" },
+    { "ASUS", "BW-16D1HT" }
+};
+
+
+void flash_mt1959(SPTD &sptd, std::span<const uint8_t> firmware_data, uint32_t block_size)
+{
+    if(auto status = cmd_write_buffer(sptd, nullptr, 0, WRITE_BUFFER_Mode::VENDOR_SPECIFIC, 0, 0); status.status_code)
+        throw_line("failed to flash firmware, SCSI ({})", SPTD::StatusMessage(status));
+
+    for(uint32_t offset = 0; offset < firmware_data.size();)
+    {
+        uint32_t size = std::min(block_size, (uint32_t)(firmware_data.size() - offset));
+        uint32_t offset_next = offset + size;
+
+        LOGC_RF("[{:3}%] flashing: [{:08X} .. {:08X})", 100 * offset / (uint32_t)firmware_data.size(), offset, offset_next);
+
+        if(auto status = cmd_write_buffer(sptd, &firmware_data[offset], size, WRITE_BUFFER_Mode::DOWNLOAD_MICROCODE_WITH_OFFSETS, offset, size); status.status_code)
+            throw_line("failed to flash firmware, SCSI ({})", SPTD::StatusMessage(status));
+
+        offset = offset_next;
+    }
+
+    cmd_drive_ready(sptd);
+
+    LOGC_RF("");
+    LOGC("flashing success");
+}
+
+
+std::vector<uint8_t> read_mt1959_config(SPTD &sptd, uint32_t config_offset, uint32_t config_size)
+{
+    std::vector<uint8_t> config(config_size);
+
+    if(auto status = cmd_read_buffer(sptd, config.data(), config.size(), READ_BUFFER_Mode::DOWNLOAD_MICROCODE_WITH_OFFSETS, config_offset, config.size()); status.status_code)
+        throw_line("failed to read drive patch configuration");
+
+    return config;
+}
+
+
+void modify_firmware(std::span<uint8_t> firmware_data, uint32_t config_offset, std::span<const uint8_t> drive_config)
+{
+    std::fill(firmware_data.begin(), firmware_data.begin() + 0x10000, (uint8_t)0xFF);
+    std::copy(drive_config.begin(), drive_config.end(), &firmware_data[config_offset]);
+}
+
+
+export int redumper_flash_mt1959(Context &ctx, Options &options)
+{
+    int exit_code = 0;
+
+    uint32_t block_size = 0x4000;
+
+    if(!options.force_flash
+        && std::find_if(MT1959_SUPPORTED_DRIVES.begin(), MT1959_SUPPORTED_DRIVES.end(), [&](const auto &d) { return d.first == ctx.drive_config.vendor_id && d.second == ctx.drive_config.product_id; })
+               == MT1959_SUPPORTED_DRIVES.end())
+        throw_line("flashing of this drive is unsupported");
+
+    uint32_t config_offset = 0x3000;
+    uint32_t config_size = 0x20;
+    auto drive_config = read_mt1959_config(*ctx.sptd, config_offset, config_size);
+
+    auto firmware_data = read_vector(options.firmware);
+    modify_firmware(firmware_data, config_offset, drive_config);
+
+    flash_mt1959(*ctx.sptd, firmware_data, block_size);
+
+    return exit_code;
+}
+
+}

--- a/drive/flash_mt1959.ixx
+++ b/drive/flash_mt1959.ixx
@@ -5,6 +5,7 @@ module;
 #include <fstream>
 #include <span>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 #include "throw_line.hh"
@@ -17,6 +18,7 @@ import scsi.cmd;
 import scsi.mmc;
 import scsi.sptd;
 import utils.file_io;
+import utils.hex_bin;
 import utils.logger;
 
 
@@ -93,6 +95,12 @@ export int redumper_flash_mt1959(Context &ctx, Options &options)
         throw_line("firmware data too small (size: {:#x}, required: {:#x})", firmware_data.size(), clear_size);
 
     auto drive_config = read_mt1959_config(*ctx.sptd, config_offset, config_size);
+    LOG("drive patch configuration (offset: 0x{:04X}, size: 0x{:X}): ", config_offset, config_size);
+    LOG("{}", hexdump(drive_config.data(), 0, (uint32_t)drive_config.size()));
+
+    if(!std::string_view((const char *)drive_config.data(), drive_config.size()).starts_with("MT1959 Boot JB8"))
+        throw_line("unexpected drive patch configuration signature");
+
     modify_firmware(firmware_data, clear_size, config_offset, drive_config);
 
     flash_mt1959(*ctx.sptd, firmware_data, block_size);

--- a/drive/flash_mt1959.ixx
+++ b/drive/flash_mt1959.ixx
@@ -60,11 +60,16 @@ void flash_mt1959(SPTD &sptd, std::span<const uint8_t> firmware_data, uint32_t b
     LOGC("");
 
     constexpr uint32_t wait_seconds = 15;
+    uint32_t ready_count = 0;
     for(uint32_t i = 0; i < wait_seconds; ++i)
     {
         LOGC_RF("waiting for drive to become ready... [{}/{}]", i + 1, wait_seconds);
         if(!cmd_drive_ready(sptd).status_code)
-            i = wait_seconds - 2;
+            ++ready_count;
+
+        if(ready_count >= 2)
+            break;
+
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 

--- a/drive/flash_mt1959.ixx
+++ b/drive/flash_mt1959.ixx
@@ -66,9 +66,9 @@ std::vector<uint8_t> read_mt1959_config(SPTD &sptd, uint32_t config_offset, uint
 }
 
 
-void modify_firmware(std::span<uint8_t> firmware_data, uint32_t config_offset, std::span<const uint8_t> drive_config)
+void modify_firmware(std::span<uint8_t> firmware_data, uint32_t clear_size, uint32_t config_offset, std::span<const uint8_t> drive_config)
 {
-    std::fill(firmware_data.begin(), firmware_data.begin() + 0x10000, (uint8_t)0xFF);
+    std::fill(firmware_data.begin(), firmware_data.begin() + clear_size, (uint8_t)0xFF);
     std::copy(drive_config.begin(), drive_config.end(), &firmware_data[config_offset]);
 }
 
@@ -84,12 +84,16 @@ export int redumper_flash_mt1959(Context &ctx, Options &options)
                == MT1959_SUPPORTED_DRIVES.end())
         throw_line("flashing of this drive is unsupported");
 
-    uint32_t config_offset = 0x3000;
-    uint32_t config_size = 0x20;
-    auto drive_config = read_mt1959_config(*ctx.sptd, config_offset, config_size);
+    constexpr uint32_t config_offset = 0x3000;
+    constexpr uint32_t config_size = 0x20;
+    constexpr uint32_t clear_size = 0x10000;
 
     auto firmware_data = read_vector(options.firmware);
-    modify_firmware(firmware_data, config_offset, drive_config);
+    if(firmware_data.size() < clear_size)
+        throw_line("firmware data too small (size: {:#x}, required: {:#x})", firmware_data.size(), clear_size);
+
+    auto drive_config = read_mt1959_config(*ctx.sptd, config_offset, config_size);
+    modify_firmware(firmware_data, clear_size, config_offset, drive_config);
 
     flash_mt1959(*ctx.sptd, firmware_data, block_size);
 

--- a/drive/flash_mt1959.ixx
+++ b/drive/flash_mt1959.ixx
@@ -26,9 +26,16 @@ import utils.logger;
 namespace gpsxre
 {
 
-const std::vector<std::pair<std::string, std::string>> MT1959_SUPPORTED_DRIVES = {
-    // { "HL-DT-ST", "BD-RE BU40N" },
-    { "ASUS", "BW-16D1HT" }
+struct DriveEntry
+{
+    std::string vendor_id;
+    std::string product_id;
+    std::string config_id;
+};
+
+const std::vector<DriveEntry> MT1959_SUPPORTED_DRIVES = {
+    { "HL-DT-ST", "BD-RE BU40N", "MT1959 Boot BU5 " },
+    { "ASUS",     "BW-16D1HT",   "MT1959 Boot JB8 " }
 };
 
 
@@ -57,6 +64,12 @@ void flash_mt1959(SPTD &sptd, std::span<const uint8_t> firmware_data, uint32_t b
 }
 
 
+std::vector<uint8_t> extract_firmware_config(std::span<const uint8_t> firmware_data, uint32_t config_offset, uint32_t config_size)
+{
+    return std::vector<uint8_t>(&firmware_data[config_offset], &firmware_data[config_offset + config_size]);
+}
+
+
 std::vector<uint8_t> read_mt1959_config(SPTD &sptd, uint32_t config_offset, uint32_t config_size)
 {
     std::vector<uint8_t> config(config_size);
@@ -79,27 +92,35 @@ export int redumper_flash_mt1959(Context &ctx, Options &options)
 {
     int exit_code = 0;
 
-    uint32_t block_size = 0x4000;
-
-    if(!options.force_flash
-        && std::find_if(MT1959_SUPPORTED_DRIVES.begin(), MT1959_SUPPORTED_DRIVES.end(), [&](const auto &d) { return d.first == ctx.drive_config.vendor_id && d.second == ctx.drive_config.product_id; })
-               == MT1959_SUPPORTED_DRIVES.end())
-        throw_line("flashing of this drive is unsupported");
-
+    constexpr uint32_t block_size = 0x4000;
     constexpr uint32_t config_offset = 0x3000;
     constexpr uint32_t config_size = 0x20;
+    constexpr uint32_t id_size = 0x10;
     constexpr uint32_t clear_size = 0x10000;
 
     auto firmware_data = read_vector(options.firmware);
     if(firmware_data.size() < clear_size)
         throw_line("firmware data too small (size: {:#x}, required: {:#x})", firmware_data.size(), clear_size);
+    auto firmware_config = extract_firmware_config(firmware_data, config_offset, config_size);
+    std::string_view firmware_id((const char *)firmware_config.data(), id_size);
+
+    if(!options.force_flash)
+    {
+        auto it = std::find_if(MT1959_SUPPORTED_DRIVES.begin(), MT1959_SUPPORTED_DRIVES.end(),
+            [&](const auto &d) { return d.vendor_id == ctx.drive_config.vendor_id && d.product_id == ctx.drive_config.product_id; });
+        if(it == MT1959_SUPPORTED_DRIVES.end())
+            throw_line("flashing of this drive is unsupported");
+        else if(firmware_id != it->config_id)
+            throw_line("unexpected firmware config id (current: {}, expected: {})", firmware_id, it->config_id);
+    }
 
     auto drive_config = read_mt1959_config(*ctx.sptd, config_offset, config_size);
+    std::string_view drive_id((const char *)drive_config.data(), id_size);
+    if(drive_id != firmware_id)
+        throw_line("firmware id mismatch (drive: {}, firmware: {})", drive_id, firmware_id);
+
     LOG("drive patch configuration (offset: 0x{:04X}, size: 0x{:X}): ", config_offset, config_size);
     LOG("{}", hexdump(drive_config.data(), 0, (uint32_t)drive_config.size()));
-
-    if(!std::string_view((const char *)drive_config.data(), drive_config.size()).starts_with("MT1959 Boot JB8"))
-        throw_line("unexpected drive patch configuration signature");
 
     modify_firmware(firmware_data, clear_size, config_offset, drive_config);
 

--- a/drive/flash_mt1959.ixx
+++ b/drive/flash_mt1959.ixx
@@ -56,8 +56,17 @@ void flash_mt1959(SPTD &sptd, std::span<const uint8_t> firmware_data, uint32_t b
 
         offset = offset_next;
     }
+    LOGC("");
+    LOGC("");
 
-    cmd_drive_ready(sptd);
+    constexpr uint32_t wait_seconds = 15;
+    for(uint32_t i = 0; i < wait_seconds; ++i)
+    {
+        LOGC_RF("waiting for drive to become ready... [{}/{}]", i + 1, wait_seconds);
+        if(!cmd_drive_ready(sptd).status_code)
+            i = wait_seconds - 2;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     LOGC_RF("");
     LOGC("flashing success");

--- a/options.ixx
+++ b/options.ixx
@@ -384,6 +384,7 @@ export struct Options
         LOG("\tinfo          \toutputs basic image information (CUE/BIN or ISO)");
         LOG("\tskeleton      \tgenerates image file with zeroed content");
         LOG("\tflash::mt1339 \tflashes MT1339 drive firmware");
+        LOG("\tflash::mt1959 \tflashes MT1959 drive firmware");
         LOG("\tflash::sd616  \tflashes SD-616F/T drive firmware");
         LOG("\tflash::plextor\tflashes PLEXTOR drive firmware");
         LOG("");

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -26,6 +26,7 @@ import cd.toc;
 import common;
 import debug;
 import drive;
+import drive.flash.mt1959;
 import drive.flash.plextor;
 import drive.flash.tsst;
 import drive.flash.sd616;
@@ -138,6 +139,7 @@ const std::map<std::string, Command> COMMANDS{
     { "flash::mt1339",  { true, false, false, false, false, redumper_flash_tsst }    },
     { "flash::sd616",   { true, false, false, false, false, redumper_flash_sd616 }   },
     { "flash::plextor", { true, false, false, false, false, redumper_flash_plextor } },
+    { "flash::mt1959",  { true, false, false, false, false, redumper_flash_mt1959 }  },
     { "subchannel",     { false, false, false, true, false, redumper_subchannel }    },
     { "debug",          { false, false, false, false, false, redumper_debug }        },
     { "fixmsf",         { false, false, false, true, false, redumper_fix_msf }       },

--- a/scsi/cmd.ixx
+++ b/scsi/cmd.ixx
@@ -455,6 +455,22 @@ export SPTD::Status cmd_write_buffer(SPTD &sptd, const uint8_t *data, uint32_t d
 }
 
 
+export SPTD::Status cmd_read_buffer(SPTD &sptd, uint8_t *data, uint32_t data_size, READ_BUFFER_Mode mode, uint32_t buffer_offset, uint32_t allocation_length)
+{
+    CDB10_ReadBuffer cdb = {};
+    cdb.operation_code = (uint8_t)CDB_OperationCode::READ_BUFFER;
+    cdb.mode = (uint8_t)mode;
+    cdb.buffer_offset[0] = ((uint8_t *)&buffer_offset)[2];
+    cdb.buffer_offset[1] = ((uint8_t *)&buffer_offset)[1];
+    cdb.buffer_offset[2] = ((uint8_t *)&buffer_offset)[0];
+    cdb.allocation_length[0] = ((uint8_t *)&allocation_length)[2];
+    cdb.allocation_length[1] = ((uint8_t *)&allocation_length)[1];
+    cdb.allocation_length[2] = ((uint8_t *)&allocation_length)[0];
+
+    return sptd.sendCommand(&cdb, sizeof(cdb), data, data_size);
+}
+
+
 export SPTD::Status cmd_read_omnidrive(SPTD &sptd, uint8_t *buffer, uint32_t block_size, int32_t address, uint32_t transfer_length, OmniDrive_DiscType disc_type, bool raw_addressing, bool fua,
     bool descramble, OmniDrive_Subchannels subchannels, bool c2)
 {

--- a/scsi/mmc.ixx
+++ b/scsi/mmc.ixx
@@ -17,6 +17,7 @@ export enum class CDB_OperationCode : uint8_t
     SEEK = 0x2B,
     SYNCHRONIZE_CACHE = 0x35,
     WRITE_BUFFER = 0x3B,
+    READ_BUFFER = 0x3C,
     READ_TOC = 0x43,
     GET_CONFIGURATION = 0x46,
     SEND_KEY = 0xA3,
@@ -890,6 +891,34 @@ export struct CDB10_WriteBuffer
     uint8_t buffer_id;
     uint8_t buffer_offset[3];
     uint8_t parameter_list_length[3];
+    uint8_t control;
+};
+
+
+export enum class READ_BUFFER_Mode : uint8_t
+{
+    READ_HEADER_DATA,
+    VENDOR_SPECIFIC,
+    READ_DATA,
+    DESCRIPTOR,
+    DOWNLOAD_MICROCODE,
+    DOWNLOAD_MICROCODE_SAVE,
+    DOWNLOAD_MICROCODE_WITH_OFFSETS,
+    DOWNLOAD_MICROCODE_WITH_OFFSETS_SAVE,
+    ECHO_BUFFER = 0x0A,
+    ECHO_BUFFER_DESCRIPTOR,
+    RESERVED2
+};
+
+
+export struct CDB10_ReadBuffer
+{
+    uint8_t operation_code;
+    uint8_t mode     :4;
+    uint8_t reserved :4;
+    uint8_t buffer_id;
+    uint8_t buffer_offset[3];
+    uint8_t allocation_length[3];
     uint8_t control;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added firmware flashing support for MT1959 drives: device validation, on-drive configuration retrieval, firmware patching, chunked flashing with progress reporting, retries, and clear error messages.
  * Added SCSI READ BUFFER support to improve device read/write operations.

* **Documentation**
  * CLI help updated to list the new MT1959 flash command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->