### PR TITLE
build fix

### DIFF
--- a/analyzers/silence.ixx
+++ b/analyzers/silence.ixx
@@ -1,4 +1,5 @@
 module;
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <utility>


### PR DESCRIPTION
Some dependency update (probably Clang) broke building on my machine. Import correct header to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal infrastructure update to support fixed-width integer type usage in the silence analyzer module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->