### PR TITLE
Don't throw error on old OmniDrive firmware

### DIFF
--- a/redumper.ixx
+++ b/redumper.ixx
@@ -496,9 +496,9 @@ export int redumper(Options &options)
         if(auto version = is_omnidrive_firmware(ctx.drive_config))
         {
             if(*version < omnidrive_minimum_version())
-                throw_line("outdated OmniDrive drive firmware (current: {}, supported: {})", omnidrive_version_string(*version), omnidrive_version_string(omnidrive_minimum_version()));
-
-            LOG("  firmware: OmniDrive {}", omnidrive_version_string(*version));
+                LOG("  outdated OmniDrive drive firmware (current: {}, recommended: {})", omnidrive_version_string(*version), omnidrive_version_string(omnidrive_minimum_version()));
+            else
+                LOG("  firmware: OmniDrive {}", omnidrive_version_string(*version));
         }
     }
 

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -496,7 +496,7 @@ export int redumper(Options &options)
         if(auto version = is_omnidrive_firmware(ctx.drive_config))
         {
             if(*version < omnidrive_minimum_version())
-                LOG("  outdated OmniDrive drive firmware (current: {}, recommended: {})", omnidrive_version_string(*version), omnidrive_version_string(omnidrive_minimum_version()));
+                LOG("  warning: outdated OmniDrive drive firmware (current: {}, recommended: {})", omnidrive_version_string(*version), omnidrive_version_string(omnidrive_minimum_version()));
             else
                 LOG("  firmware: OmniDrive {}", omnidrive_version_string(*version));
         }


### PR DESCRIPTION
Log that the user is using outdated OmniDrive firmware instead of throwing an error. This allows them to use redumper to flash to newer OmniDrive versions. Redumper also shouldn't refuse to dump just because of unsupported firmware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Outdated OmniDrive firmware now shows a non-fatal warning instead of terminating the process.
  * Warning displays both the detected (current) firmware and the recommended version.
  * Message wording updated to indicate the firmware is "recommended" rather than "supported."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->