### PR TITLE
Don't install gtest to build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(FetchContent)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git


### PR DESCRIPTION
This removes the unnecessary include and lib folders from the redumper release archives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure build configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->