### PR TITLE
Print PS3 firmware version

### DIFF
--- a/systems/ps3.ixx
+++ b/systems/ps3.ixx
@@ -206,9 +206,9 @@ private:
             if(endian_swap(file->type) == 0x100)
             {
                 uint64_t version_offset = endian_swap(file->offset);
-                if(version_offset + 4 > sector_buffer.size())
+                if(version_offset > sector_buffer.size() - _VERSION_LENGTH)
                     return "";
-                return std::string((char *)(sector_buffer.data() + version_offset), 4);
+                return std::string((char *)(sector_buffer.data() + version_offset), _VERSION_LENGTH);
             }
         }
 

--- a/systems/ps3.ixx
+++ b/systems/ps3.ixx
@@ -1,4 +1,5 @@
 module;
+#include <cstring>
 #include <filesystem>
 #include <format>
 #include <map>
@@ -85,7 +86,20 @@ public:
     }
 
 private:
-    static constexpr uint32_t PUP_FILE_OFFSET = 0x3E;
+    static constexpr std::string_view _PUP_MAGIC = "SCEUF\0\0\0";
+    static constexpr uint64_t _VERSION_ID = 0x100;
+    static constexpr uint32_t _VERSION_LENGTH = 4;
+
+    struct PUPHeader
+    {
+        uint8_t magic[8];
+        uint64_t version;
+        uint64_t build;
+        uint64_t records_count;
+        uint64_t header_size;
+        uint64_t data_size;
+    };
+
     struct SFBHeader
     {
         uint8_t magic[4];
@@ -169,20 +183,51 @@ private:
         if(data_reader->read(sector_buffer.data(), pup_file->sectorsLBA(), 1) != 1)
             return firmware_version;
 
-        uint32_t version_offset = ((uint32_t)sector_buffer[PUP_FILE_OFFSET] << 8) | sector_buffer[PUP_FILE_OFFSET + 1];
-        if(version_offset == 0)
+        auto header = (PUPHeader *)sector_buffer.data();
+
+        // check for valid PUP file
+        if(memcmp(header->magic, _PUP_MAGIC.data(), _PUP_MAGIC.size()))
             return firmware_version;
 
-        if(version_offset >= data_reader->sectorSize())
+        // find version record offset
+        uint64_t version_offset;
+        uint32_t sector_number = 0;
+        uint32_t cur = sizeof(PUPHeader);
+        uint64_t records_count = endian_swap(header->records_count);
+        for(uint64_t i = 0; i < records_count; ++i)
         {
-            uint32_t target_sector = pup_file->sectorsLBA() + version_offset / data_reader->sectorSize();
-            if(data_reader->read(sector_buffer.data(), target_sector, 1) != 1)
+            // read next sector if needed
+            if(cur + 4 * sizeof(uint64_t) >= data_reader->sectorSize())
+            {
+                sector_number += 1;
+                uint32_t target_sector = pup_file->sectorsLBA() + sector_number;
+                if(data_reader->read(sector_buffer.data(), target_sector, 1) != 1)
+                    return firmware_version;
+                cur = 0;
+            }
+
+            uint64_t record_type = endian_swap(*(uint64_t *)&sector_buffer[cur]);
+            if(record_type == _VERSION_ID)
+            {
+                version_offset = endian_swap(*(uint64_t *)&sector_buffer[cur + sizeof(uint64_t)]);
+                break;
+            }
+
+            cur += 4 * sizeof(uint64_t);
+        }
+
+        // read sector that version.txt is in
+        uint32_t version_sector = version_offset / data_reader->sectorSize();
+        if(version_sector != sector_number)
+        {
+            if(data_reader->read(sector_buffer.data(), pup_file->sectorsLBA() + version_sector, 1) != 1)
                 return firmware_version;
         }
 
+        // read 4-byte string from version.txt
         uint32_t relative_offset = version_offset % data_reader->sectorSize();
-        if(relative_offset + 4 <= sector_buffer.size())
-            firmware_version.assign((char *)&sector_buffer[relative_offset], 4);
+        if(relative_offset + _VERSION_LENGTH <= sector_buffer.size())
+            firmware_version.assign((char *)&sector_buffer[relative_offset], _VERSION_LENGTH);
 
         return firmware_version;
     }

--- a/systems/ps3.ixx
+++ b/systems/ps3.ixx
@@ -5,6 +5,7 @@ module;
 #include <ostream>
 #include <span>
 #include <string_view>
+#include <vector>
 #include "system.hh"
 #include "throw_line.hh"
 
@@ -77,9 +78,14 @@ public:
 
         if(!serial.empty())
             os << std::format("  serial: {}", serial) << std::endl;
+
+        auto firmware_version = pupVersion(data_reader, root_directory->subEntry("PS3_UPDATE/PS3UPDAT.PUP"));
+        if(!firmware_version.empty())
+            os << std::format("  firmware version: {}", firmware_version) << std::endl;
     }
 
 private:
+    static constexpr uint32_t PUP_FILE_OFFSET = 0x3E;
     struct SFBHeader
     {
         uint8_t magic[4];
@@ -150,6 +156,32 @@ private:
         }
 
         return sfb;
+    }
+
+    std::string pupVersion(DataReader *data_reader, std::shared_ptr<iso9660::Entry> pup_file) const
+    {
+        std::string firmware_version;
+
+        if(!pup_file)
+            return firmware_version;
+
+        std::vector<uint8_t> sector_buffer(data_reader->sectorSize());
+        if(data_reader->read(sector_buffer.data(), pup_file->sectorsLBA(), 1) != 1)
+            return firmware_version;
+
+        uint32_t version_offset = ((uint32_t)sector_buffer[PUP_FILE_OFFSET] << 8) | sector_buffer[PUP_FILE_OFFSET + 1];
+        if(version_offset >= data_reader->sectorSize())
+        {
+            uint32_t target_sector = pup_file->sectorsLBA() + version_offset / data_reader->sectorSize();
+            if(data_reader->read(sector_buffer.data(), target_sector, 1) != 1)
+                return firmware_version;
+        }
+
+        uint32_t relative_offset = version_offset % data_reader->sectorSize();
+        if(relative_offset + 4 <= sector_buffer.size())
+            firmware_version.assign((char *)&sector_buffer[relative_offset], 4);
+
+        return firmware_version;
     }
 
 protected:

--- a/systems/ps3.ixx
+++ b/systems/ps3.ixx
@@ -100,6 +100,14 @@ private:
         uint64_t data_size;
     };
 
+    struct PUPFile
+    {
+        uint64_t type;
+        uint64_t offset;
+        uint64_t size;
+        uint64_t padding;
+    };
+
     struct SFBHeader
     {
         uint8_t magic[4];
@@ -174,62 +182,37 @@ private:
 
     std::string pupVersion(DataReader *data_reader, std::shared_ptr<iso9660::Entry> pup_file) const
     {
-        std::string firmware_version;
-
         if(!pup_file)
-            return firmware_version;
+            return "";
 
         std::vector<uint8_t> sector_buffer(data_reader->sectorSize());
         if(data_reader->read(sector_buffer.data(), pup_file->sectorsLBA(), 1) != 1)
-            return firmware_version;
+            return "";
 
         auto header = (PUPHeader *)sector_buffer.data();
 
-        // check for valid PUP file
         if(memcmp(header->magic, _PUP_MAGIC.data(), _PUP_MAGIC.size()))
-            return firmware_version;
+            return "";
 
-        // find version record offset
-        uint64_t version_offset;
-        uint32_t sector_number = 0;
         uint32_t cur = sizeof(PUPHeader);
         uint64_t records_count = endian_swap(header->records_count);
         for(uint64_t i = 0; i < records_count; ++i)
         {
-            // read next sector if needed
-            if(cur + 4 * sizeof(uint64_t) >= data_reader->sectorSize())
-            {
-                sector_number += 1;
-                uint32_t target_sector = pup_file->sectorsLBA() + sector_number;
-                if(data_reader->read(sector_buffer.data(), target_sector, 1) != 1)
-                    return firmware_version;
-                cur = 0;
-            }
+            if(cur + sizeof(PUPFile) > sector_buffer.size())
+                return "";
 
-            uint64_t record_type = endian_swap(*(uint64_t *)&sector_buffer[cur]);
-            if(record_type == _VERSION_ID)
+            auto file = (PUPFile *)(sector_buffer.data() + cur);
+            cur += sizeof(PUPFile);
+            if(endian_swap(file->type) == 0x100)
             {
-                version_offset = endian_swap(*(uint64_t *)&sector_buffer[cur + sizeof(uint64_t)]);
-                break;
+                uint64_t version_offset = endian_swap(file->offset);
+                if(version_offset + 4 > sector_buffer.size())
+                    return "";
+                return std::string((char *)(sector_buffer.data() + version_offset), 4);
             }
-
-            cur += 4 * sizeof(uint64_t);
         }
 
-        // read sector that version.txt is in
-        uint32_t version_sector = version_offset / data_reader->sectorSize();
-        if(version_sector != sector_number)
-        {
-            if(data_reader->read(sector_buffer.data(), pup_file->sectorsLBA() + version_sector, 1) != 1)
-                return firmware_version;
-        }
-
-        // read 4-byte string from version.txt
-        uint32_t relative_offset = version_offset % data_reader->sectorSize();
-        if(relative_offset + _VERSION_LENGTH <= sector_buffer.size())
-            firmware_version.assign((char *)&sector_buffer[relative_offset], _VERSION_LENGTH);
-
-        return firmware_version;
+        return "";
     }
 
 protected:

--- a/systems/ps3.ixx
+++ b/systems/ps3.ixx
@@ -170,6 +170,9 @@ private:
             return firmware_version;
 
         uint32_t version_offset = ((uint32_t)sector_buffer[PUP_FILE_OFFSET] << 8) | sector_buffer[PUP_FILE_OFFSET + 1];
+        if(version_offset == 0)
+            return firmware_version;
+
         if(version_offset >= data_reader->sectorSize())
         {
             uint32_t target_sector = pup_file->sectorsLBA() + version_offset / data_reader->sectorSize();


### PR DESCRIPTION
Prints PS3 Firmware version as part of `redumper info`
e.g. `firmware version: 2.80`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PS3 system information now extracts and displays the firmware version from the console update file inside the disc image.
  * Firmware details are shown alongside existing version and serial information to improve diagnostics and visibility; the extractor fails gracefully when an update file or valid version cannot be read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->