### PR TITLE
Add new Drives

### DIFF
--- a/drive.ixx
+++ b/drive.ixx
@@ -179,6 +179,8 @@ static const std::vector<DriveConfig> DRIVE_DATABASE =
     { "HL-DT-ST", "BD-RE BP55EB40"   , "1.00", "", "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::MTK2B }, // AngelDevIndie
     // PATCHED
     { "TSSTcorp", "DVD-ROM TS-H353C" , "ZZ00", ""                    , "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // MoriGM
+    { "HL-DT-ST", "DVD-ROM DH41N"    , "ZZ00", ""                    , "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // MoriGM
+    { "PLDS"    , "DVD-ROM DH-16D5S" , "ZZ00", "2025-06-18 15:03 Fen", "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // MoriGM
     { "hp"      , "DVD RW AD-7290H5" , "SE02", ""                    , "",  +48,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // seri
     { "Optiarc" , "DVD RW AD-7173A"  , "1-04", "seri-v1    BT-LIGGY" , "",  +48,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // seri
     { "NEC"     , "DVD_RW ND-3520AW" , "3.07", "seri-01 BT-LIGGY"    , "",  +48,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // seri
@@ -190,6 +192,8 @@ static const std::vector<DriveConfig> DRIVE_DATABASE =
     { "Optiarc" , "DVD RW AD-7203A"  , "1.09", "seri-01 BT-LIGGY"    , "",  +48,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // seri
     // PATCHED KREON
     { "TSSTcorp", "DVD-ROM SH-D163B" , "ZZ01", "KREON V1.00.........", "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // MoriGM
+    { "TSSTcorp", "DVD-ROM SH-D163A" , "DC02", "KREON V1.00.........", "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_SUB_C2, Type::GENERIC  }, // MoriGM
+    { "TSSTcorp", "DVD-ROM SH-D162D" , "ZZ01", "KREON V1.00.........", "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // MoriGM
     { "TSSTcorp", "DVD-ROM SH-D162C" , "DC02", "KREON V1.00.........", "",   +6,   0, -135, ReadMethod::BE, SectorOrder::DATA_SUB_C2, Type::GENERIC  }, // MoriGM
 
     // RECOMMENDED (GOOD) DRIVES ABOVE THIS LINE


### PR DESCRIPTION
Add missing two Kreon drives and the new two MT1339E drives.

I added the logs for the new two drives.
[DH16D5S.log](https://github.com/user-attachments/files/28717166/DH16D5S.log)
[DH41N.log](https://github.com/user-attachments/files/28717167/DH41N.log)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for additional DVD-ROM drive models and their firmware variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->