### PR TITLE
Extract Content IDs from PS4/PS5 PKGs

### DIFF
--- a/systems/ps4.ixx
+++ b/systems/ps4.ixx
@@ -4,6 +4,7 @@ module;
 #include <map>
 #include <ostream>
 #include <span>
+#include <vector>
 #include "system.hh"
 #include "throw_line.hh"
 

--- a/systems/ps4.ixx
+++ b/systems/ps4.ixx
@@ -64,7 +64,7 @@ public:
     }
 
 protected:
-    std:: string getContentIds(std::shared_ptr<iso9660::Entry> root_directory, std::string pkg_name) const
+    std::string getContentIds(std::shared_ptr<iso9660::Entry> root_directory, const std::string pkg_name) const
     {
         auto app_directory = root_directory->subEntry("app");
         if(!app_directory)
@@ -79,32 +79,28 @@ protected:
                 continue;
 
             auto app_pkg_entry = e->subEntry(pkg_name);
-            if (!app_pkg_entry)
+            if(!app_pkg_entry)
                 continue;
 
             auto app_pkg_raw = app_pkg_entry->read();
 
-            const uint32_t pkg_magic_const = 0x7F434E54;
-            const uint32_t pkg_magic_offset = 0x00;
-            const uint32_t pkg_magic_size = 4;
-
-            uint32_t app_pkg_magic = 
-                (static_cast<uint32_t>(app_pkg_raw[pkg_magic_offset + 0]) << 24) |
-                (static_cast<uint32_t>(app_pkg_raw[pkg_magic_offset + 1]) << 16) |
-                (static_cast<uint32_t>(app_pkg_raw[pkg_magic_offset + 2]) << 8)  |
-                (static_cast<uint32_t>(app_pkg_raw[pkg_magic_offset + 3]) << 0);
-
-            if(pkg_magic_const != app_pkg_magic)
+            if(app_pkg_raw.size() < _PKG_HEADER_SIZE)
                 continue;
 
-            const uint32_t pkg_content_id_offset = 0x40;
-            const uint32_t pkg_content_id_size = 36;
+            uint32_t app_pkg_magic = 
+                (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 0]) << 24) |
+                (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 1]) << 16) |
+                (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 2]) << 8)  |
+                (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 3]) << 0);
 
-            std::span<uint8_t> app_pkg_content_id(app_pkg_raw.data() + pkg_content_id_offset, pkg_content_id_size);
+            if(app_pkg_magic != _PKG_MAGIC)
+                continue;
 
-            std::string_view app_pkg_content_id_text(reinterpret_cast<const char*>(app_pkg_content_id.data()), pkg_content_id_size);
+            std::span<const uint8_t> app_pkg_content_id(app_pkg_raw.data() + _PKG_CONTENT_ID_OFFSET, _PKG_CONTENT_ID_SIZE);
 
-            if (!content_ids.empty())
+            std::string_view app_pkg_content_id_text(reinterpret_cast<const char*>(app_pkg_content_id.data()), _PKG_CONTENT_ID_SIZE);
+
+            if(!content_ids.empty())
                 content_ids += ", ";
 
             content_ids += app_pkg_content_id_text;
@@ -112,6 +108,13 @@ protected:
 
         return content_ids;
     }
+
+private:
+    static constexpr uint32_t _PKG_HEADER_SIZE = 0x1000;
+    static constexpr uint32_t _PKG_MAGIC = 0x7F434E54;
+    static constexpr uint32_t _PKG_MAGIC_OFFSET = 0x00;
+    static constexpr uint32_t _PKG_CONTENT_ID_OFFSET = 0x40;
+    static constexpr uint32_t _PKG_CONTENT_ID_SIZE = 36;
 };
 
 }

--- a/systems/ps4.ixx
+++ b/systems/ps4.ixx
@@ -54,6 +54,63 @@ public:
             serial.insert(4, "-");
             os << std::format("  serial: {}", serial) << std::endl;
         }
+
+        std::string content_ids = getContentIds(root_directory, "app.pkg");
+
+        if(content_ids.empty())
+            return;
+
+        os << std::format("  content ID(s): {}", content_ids) << std::endl;
+    }
+
+protected:
+    std:: string getContentIds(std::shared_ptr<iso9660::Entry> root_directory, std::string pkg_name) const
+    {
+        auto app_directory = root_directory->subEntry("app");
+        if(!app_directory)
+            return "";
+
+        auto app_directory_entries = app_directory->entries();
+        std::string content_ids;
+
+        for(auto &e : app_directory_entries)
+        {
+            if(!e->isDirectory())
+                continue;
+
+            auto app_pkg_entry = e->subEntry(pkg_name);
+            if (!app_pkg_entry)
+                continue;
+
+            auto app_pkg_raw = app_pkg_entry->read();
+
+            const uint32_t pkg_magic_const = 0x7F434E54;
+            const uint32_t pkg_magic_offset = 0x00;
+            const uint32_t pkg_magic_size = 4;
+
+            uint32_t app_pkg_magic = 
+                (static_cast<uint32_t>(app_pkg_raw[pkg_magic_offset + 0]) << 24) |
+                (static_cast<uint32_t>(app_pkg_raw[pkg_magic_offset + 1]) << 16) |
+                (static_cast<uint32_t>(app_pkg_raw[pkg_magic_offset + 2]) << 8)  |
+                (static_cast<uint32_t>(app_pkg_raw[pkg_magic_offset + 3]) << 0);
+
+            if(pkg_magic_const != app_pkg_magic)
+                continue;
+
+            const uint32_t pkg_content_id_offset = 0x40;
+            const uint32_t pkg_content_id_size = 36;
+
+            std::span<uint8_t> app_pkg_content_id(app_pkg_raw.data() + pkg_content_id_offset, pkg_content_id_size);
+
+            std::string_view app_pkg_content_id_text(reinterpret_cast<const char*>(app_pkg_content_id.data()), pkg_content_id_size);
+
+            if (!content_ids.empty())
+                content_ids += ", ";
+
+            content_ids += app_pkg_content_id_text;
+        }
+
+        return content_ids;
     }
 };
 

--- a/systems/ps4.ixx
+++ b/systems/ps4.ixx
@@ -55,7 +55,7 @@ public:
             os << std::format("  serial: {}", serial) << std::endl;
         }
 
-        std::string content_ids = getContentIds(root_directory, "app.pkg");
+        std::string content_ids = getContentIds(root_directory, _PKG_FILE_NAMES);
 
         if(content_ids.empty())
             return;
@@ -64,7 +64,7 @@ public:
     }
 
 protected:
-    std::string getContentIds(std::shared_ptr<iso9660::Entry> root_directory, const std::string pkg_name) const
+    std::string getContentIds(std::shared_ptr<iso9660::Entry> root_directory, std::span<const std::string> pkg_file_names) const
     {
         auto app_directory = root_directory->subEntry("app");
         if(!app_directory)
@@ -78,32 +78,37 @@ protected:
             if(!e->isDirectory())
                 continue;
 
-            auto app_pkg_entry = e->subEntry(pkg_name);
-            if(!app_pkg_entry)
-                continue;
+            for(const auto& pkg_file_name : pkg_file_names)
+            {
+                auto app_pkg_entry = e->subEntry(pkg_file_name);
+                if(!app_pkg_entry)
+                    continue;
 
-            auto app_pkg_raw = app_pkg_entry->read();
+                auto app_pkg_raw = app_pkg_entry->read();
 
-            if(app_pkg_raw.size() < _PKG_HEADER_SIZE)
-                continue;
+                if(app_pkg_raw.size() < _PKG_HEADER_SIZE)
+                    continue;
 
-            uint32_t app_pkg_magic = 
-                (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 0]) << 24) |
-                (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 1]) << 16) |
-                (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 2]) << 8)  |
-                (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 3]) << 0);
+                uint32_t app_pkg_magic = 
+                    (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 0]) << 24) |
+                    (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 1]) << 16) |
+                    (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 2]) << 8)  |
+                    (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 3]) << 0);
 
-            if(app_pkg_magic != _PKG_MAGIC)
-                continue;
+                if(app_pkg_magic != _PKG_MAGIC)
+                    continue;
 
-            std::span<const uint8_t> app_pkg_content_id(app_pkg_raw.data() + _PKG_CONTENT_ID_OFFSET, _PKG_CONTENT_ID_SIZE);
+                std::span<const uint8_t> app_pkg_content_id(app_pkg_raw.data() + _PKG_CONTENT_ID_OFFSET, _PKG_CONTENT_ID_SIZE);
 
-            std::string_view app_pkg_content_id_text(reinterpret_cast<const char*>(app_pkg_content_id.data()), _PKG_CONTENT_ID_SIZE);
+                std::string_view app_pkg_content_id_text(reinterpret_cast<const char*>(app_pkg_content_id.data()), _PKG_CONTENT_ID_SIZE);
 
-            if(!content_ids.empty())
-                content_ids += ", ";
+                if(!content_ids.empty())
+                    content_ids += ", ";
 
-            content_ids += app_pkg_content_id_text;
+                content_ids += app_pkg_content_id_text;
+
+                break;
+            }
         }
 
         return content_ids;
@@ -115,6 +120,7 @@ private:
     static constexpr uint32_t _PKG_MAGIC_OFFSET = 0x00;
     static constexpr uint32_t _PKG_CONTENT_ID_OFFSET = 0x40;
     static constexpr uint32_t _PKG_CONTENT_ID_SIZE = 36;
+    static constexpr std::array<std::string, 3> _PKG_FILE_NAMES = {"app.pkg", "app_h.pkg", "app_0.pkg"};
 };
 
 }

--- a/systems/ps4.ixx
+++ b/systems/ps4.ixx
@@ -9,9 +9,11 @@ module;
 
 export module systems.ps4;
 
+import cd.cdrom;
 import filesystem.iso9660;
 import readers.data_reader;
 import systems.ps3;
+import utils.endian;
 
 
 
@@ -55,7 +57,7 @@ public:
             os << std::format("  serial: {}", serial) << std::endl;
         }
 
-        std::string content_ids = getContentIds(root_directory, _PKG_FILE_NAMES);
+        std::string content_ids = getContentIds(data_reader, root_directory, _PKG_FILE_NAMES);
 
         if(content_ids.empty())
             return;
@@ -64,7 +66,7 @@ public:
     }
 
 protected:
-    std::string getContentIds(std::shared_ptr<iso9660::Entry> root_directory, std::span<const std::string> pkg_file_names) const
+    std::string getContentIds(DataReader *data_reader, std::shared_ptr<iso9660::Entry> root_directory, std::span<const std::string> pkg_file_names) const
     {
         auto app_directory = root_directory->subEntry("app");
         if(!app_directory)
@@ -84,28 +86,18 @@ protected:
                 if(!app_pkg_entry)
                     continue;
 
-                auto app_pkg_raw = app_pkg_entry->read();
+                std::vector<uint8_t> app_pkg_header(FORM1_DATA_SIZE);
+                data_reader->read((uint8_t *)app_pkg_header.data(), app_pkg_entry->sectorsLBA(), 1);
+                auto pkg_header = (PkgHeader *)app_pkg_header.data();
+                pkg_header->swapEndianness();
 
-                if(app_pkg_raw.size() < _PKG_HEADER_SIZE)
+                if(pkg_header->pkg_magic != _PKG_MAGIC)
                     continue;
-
-                uint32_t app_pkg_magic = 
-                    (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 0]) << 24) |
-                    (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 1]) << 16) |
-                    (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 2]) << 8)  |
-                    (static_cast<uint32_t>(app_pkg_raw[_PKG_MAGIC_OFFSET + 3]) << 0);
-
-                if(app_pkg_magic != _PKG_MAGIC)
-                    continue;
-
-                std::span<const uint8_t> app_pkg_content_id(app_pkg_raw.data() + _PKG_CONTENT_ID_OFFSET, _PKG_CONTENT_ID_SIZE);
-
-                std::string_view app_pkg_content_id_text(reinterpret_cast<const char*>(app_pkg_content_id.data()), _PKG_CONTENT_ID_SIZE);
 
                 if(!content_ids.empty())
                     content_ids += ", ";
 
-                content_ids += app_pkg_content_id_text;
+                content_ids += std::string(reinterpret_cast<const char*>(pkg_header->pkg_content_id), sizeof(pkg_header->pkg_content_id));
 
                 break;
             }
@@ -115,12 +107,42 @@ protected:
     }
 
 private:
-    static constexpr uint32_t _PKG_HEADER_SIZE = 0x1000;
     static constexpr uint32_t _PKG_MAGIC = 0x7F434E54;
-    static constexpr uint32_t _PKG_MAGIC_OFFSET = 0x00;
-    static constexpr uint32_t _PKG_CONTENT_ID_OFFSET = 0x40;
-    static constexpr uint32_t _PKG_CONTENT_ID_SIZE = 36;
     static constexpr std::array<std::string, 3> _PKG_FILE_NAMES = {"app.pkg", "app_h.pkg", "app_0.pkg"};
+
+    struct PkgHeader
+    {
+        uint32_t pkg_magic;
+        uint32_t pkg_type;
+        uint32_t pkg_0x008;
+        uint32_t pkg_file_count;
+        uint32_t pkg_entry_count;
+        uint16_t pkg_sc_entry_count;
+        uint16_t pkg_entry_count_2;
+        uint32_t pkg_table_offset;
+        uint32_t pkg_entry_data_size;
+        uint64_t pkg_body_offset;
+        uint64_t pkg_body_size;
+        uint64_t pkg_content_offset;
+        uint64_t pkg_content_size;
+        unsigned char pkg_content_id[0x24];  
+
+        void swapEndianness() {
+            pkg_magic = endian_swap(pkg_magic);
+            pkg_type = endian_swap(pkg_type);
+            pkg_0x008 = endian_swap(pkg_0x008);
+            pkg_file_count = endian_swap(pkg_file_count);
+            pkg_entry_count = endian_swap(pkg_entry_count);
+            pkg_sc_entry_count = endian_swap(pkg_sc_entry_count);
+            pkg_entry_count_2 = endian_swap(pkg_entry_count_2);
+            pkg_table_offset = endian_swap(pkg_table_offset);
+            pkg_entry_data_size = endian_swap(pkg_entry_data_size);
+            pkg_body_offset = endian_swap(pkg_body_offset);
+            pkg_body_size = endian_swap(pkg_body_size);
+            pkg_content_offset = endian_swap(pkg_content_offset);
+            pkg_content_size = endian_swap(pkg_content_size);
+        };
+    };
 };
 
 }

--- a/systems/ps4.ixx
+++ b/systems/ps4.ixx
@@ -1,4 +1,5 @@
 module;
+#include <array>
 #include <filesystem>
 #include <format>
 #include <map>

--- a/systems/ps4.ixx
+++ b/systems/ps4.ixx
@@ -80,7 +80,7 @@ protected:
             if(!e->isDirectory())
                 continue;
 
-            for(const auto& pkg_file_name : pkg_file_names)
+            for(const auto &pkg_file_name : pkg_file_names)
             {
                 auto app_pkg_entry = e->subEntry(pkg_file_name);
                 if(!app_pkg_entry)
@@ -97,7 +97,7 @@ protected:
                 if(!content_ids.empty())
                     content_ids += ", ";
 
-                content_ids += std::string(reinterpret_cast<const char*>(pkg_header->pkg_content_id), sizeof(pkg_header->pkg_content_id));
+                content_ids += std::string(reinterpret_cast<const char *>(pkg_header->pkg_content_id), sizeof(pkg_header->pkg_content_id));
 
                 break;
             }
@@ -108,7 +108,7 @@ protected:
 
 private:
     static constexpr uint32_t _PKG_MAGIC = 0x7F434E54;
-    static constexpr std::array<std::string, 3> _PKG_FILE_NAMES = {"app.pkg", "app_h.pkg", "app_0.pkg"};
+    static constexpr std::array<std::string, 3> _PKG_FILE_NAMES = { "app.pkg", "app_h.pkg", "app_0.pkg" };
 
     struct PkgHeader
     {
@@ -125,9 +125,10 @@ private:
         uint64_t pkg_body_size;
         uint64_t pkg_content_offset;
         uint64_t pkg_content_size;
-        unsigned char pkg_content_id[0x24];  
+        unsigned char pkg_content_id[0x24];
 
-        void swapEndianness() {
+        void swapEndianness()
+        {
             pkg_magic = endian_swap(pkg_magic);
             pkg_type = endian_swap(pkg_type);
             pkg_0x008 = endian_swap(pkg_0x008);

--- a/systems/ps5.ixx
+++ b/systems/ps5.ixx
@@ -50,7 +50,7 @@ public:
         if(auto it = param_json.find("masterDataId"); it != param_json.end())
             os << std::format("  serial: {}", it->second.insert(4, "-")) << std::endl;
 
-        std::string content_ids = getContentIds(root_directory, "app_sc.pkg");
+        std::string content_ids = getContentIds(root_directory, _PKG_FILE_NAMES);
 
         if(content_ids.empty())
             return;
@@ -59,6 +59,8 @@ public:
     }
 
 private:
+    static constexpr std::array<std::string, 1> _PKG_FILE_NAMES = {"app_sc.pkg"};
+
     std::map<std::string, std::string> loadJSON(std::shared_ptr<iso9660::Entry> json_entry) const
     {
         std::map<std::string, std::string> json;

--- a/systems/ps5.ixx
+++ b/systems/ps5.ixx
@@ -11,6 +11,7 @@ export module systems.ps5;
 
 import filesystem.iso9660;
 import readers.data_reader;
+import systems.ps4;
 import utils.misc;
 import utils.strings;
 
@@ -19,7 +20,7 @@ import utils.strings;
 namespace gpsxre
 {
 
-export class SystemPS5 : public System
+export class SystemPS5 : public SystemPS4
 {
 public:
     std::string getName() override
@@ -48,6 +49,13 @@ public:
 
         if(auto it = param_json.find("masterDataId"); it != param_json.end())
             os << std::format("  serial: {}", it->second.insert(4, "-")) << std::endl;
+
+        std::string content_ids = getContentIds(root_directory, "app_sc.pkg");
+
+        if(content_ids.empty())
+            return;
+
+        os << std::format("  content ID(s): {}", content_ids) << std::endl;
     }
 
 private:

--- a/systems/ps5.ixx
+++ b/systems/ps5.ixx
@@ -50,7 +50,7 @@ public:
         if(auto it = param_json.find("masterDataId"); it != param_json.end())
             os << std::format("  serial: {}", it->second.insert(4, "-")) << std::endl;
 
-        std::string content_ids = getContentIds(root_directory, _PKG_FILE_NAMES);
+        std::string content_ids = getContentIds(data_reader, root_directory, _PKG_FILE_NAMES);
 
         if(content_ids.empty())
             return;

--- a/systems/ps5.ixx
+++ b/systems/ps5.ixx
@@ -59,7 +59,7 @@ public:
     }
 
 private:
-    static constexpr std::array<std::string, 1> _PKG_FILE_NAMES = {"app_sc.pkg"};
+    static constexpr std::array<std::string, 1> _PKG_FILE_NAMES = { "app_sc.pkg" };
 
     std::map<std::string, std::string> loadJSON(std::shared_ptr<iso9660::Entry> json_entry) const
     {


### PR DESCRIPTION
Reads the Content ID from the PKG headers found on the disc for PS4/PS5 system in `app` directory that match provided filename and prints them as part of `redump info`.

<img width="973" height="831" alt="image" src="https://github.com/user-attachments/assets/e8775d76-9545-4f4d-b5f4-437f31250d26" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PS4 system information now extracts and displays package content IDs from supported ISO package files when available.
  * PS5 system information now also collects and displays package content IDs (for example, from `app_sc.pkg`) during its info output.
* **Refactor**
  * Content ID discovery logic was consolidated for consistent PS4/PS5 output, including automatically omitting the content ID line when none are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->