### PR TITLE
Stop generating DVD ecc and replace with null bytes

### DIFF
--- a/dvd/dvd.ixx
+++ b/dvd/dvd.ixx
@@ -121,37 +121,6 @@ export struct RecordingFrame
 };
 
 
-void compute_parity_inner(std::span<uint8_t> parity_inner, std::span<const uint8_t> main_data)
-{
-    // PI: RS(n,k,d) where n=data_size+parity_size, k=data_size, d=parity_size
-    // generator polynomial roots: alpha^0, alpha^1, ..., alpha^(parity_size-1)
-    uint8_t parity[ECC_FRAMES] = {};
-    for(uint32_t col = 0; col < main_data.size(); ++col)
-    {
-        uint8_t feedback = gf.add(main_data[col], parity[0]);
-        for(uint32_t j = 0; j < parity_inner.size() - 1; ++j)
-            parity[j] = gf.add(parity[j + 1], gf.mul(feedback, gf.exp[parity_inner.size() - 1 - j]));
-        parity[parity_inner.size() - 1] = gf.mul(feedback, gf.exp[0]);
-    }
-    for(uint32_t j = 0; j < parity_inner.size(); ++j)
-        parity_inner[j] = parity[parity_inner.size() - 1 - j];
-}
-
-
-void compute_parity_outer(std::span<uint8_t> parity_outer, std::span<const uint8_t> main_data, uint32_t stride)
-{
-    // PO: simplified single-frame encoding
-    // treat each column as data_size bytes and compute 1 parity byte
-    for(uint32_t col = 0; col < parity_outer.size(); ++col)
-    {
-        uint8_t parity = 0;
-        for(uint32_t row = 0; row < main_data.size() / stride; ++row)
-            parity = gf.add(parity, main_data[row * stride + col]);
-        parity_outer[col] = parity;
-    }
-}
-
-
 export RecordingFrame DataFrame_to_RecordingFrame(const DataFrame &data_frame)
 {
     RecordingFrame recording_frame = {};
@@ -160,11 +129,6 @@ export RecordingFrame DataFrame_to_RecordingFrame(const DataFrame &data_frame)
 
     for(uint32_t i = 0; i < std::size(recording_frame.row); ++i)
         std::copy_n(src + i * std::size(recording_frame.row[i].main_data), std::size(recording_frame.row[i].main_data), recording_frame.row[i].main_data);
-
-    for(uint32_t i = 0; i < std::size(recording_frame.row); ++i)
-        compute_parity_inner(recording_frame.row[i].parity_inner, recording_frame.row[i].main_data);
-
-    compute_parity_outer(recording_frame.parity_outer, std::span((uint8_t *)recording_frame.row, sizeof(recording_frame.row)), sizeof(recording_frame.row[0]));
 
     return recording_frame;
 }


### PR DESCRIPTION
Maybe one day Omnidrive will let us get this data directly but for now, its better to not generate ECC based on potentially incorrect sector data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame conversion behavior by no longer altering parity/ECC data during recording frame creation.
  * Recording frames now keep default zeroed parity buffers, while conversion back to data frames remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->