### PR TITLE
Use system GTest if available

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG        v1.15.2
+    FIND_PACKAGE_ARGS NAMES GTest
 )
 if(MSVC)
     set(gtest_force_shared_crt OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
For build environments without internet access (common for Linux distributions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s test dependency configuration to better detect GoogleTest during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->