### PR TITLE
Allow overriding linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,8 @@ endif()
 target_link_libraries(redumper ${libs})
 
 if(REDUMPER_TARGET_LINUX)
-    target_link_options(redumper PRIVATE "-static")
+    set(REDUMPER_LINKER_FLAGS "-static" CACHE STRING "Linker flags")
+    target_link_options(redumper PRIVATE "${REDUMPER_LINKER_FLAGS}")
 endif()
 
 install(TARGETS redumper DESTINATION "bin")


### PR DESCRIPTION
Allows dynamic linking, which is required for packaging in some Linux distributions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux builds are now configurable to override the default static-linking behavior, allowing dynamically linked binaries when desired.

* **Bug Fixes**
  * Improved build flexibility by letting linker flags be set via the CMake cache, instead of being fixed to `-static`, helping compatibility across different environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->