### PR TITLE
Implement generic drive lead-in reading

### DIFF
--- a/cd/cd_dump_extra.ixx
+++ b/cd/cd_dump_extra.ixx
@@ -309,6 +309,93 @@ void mediatek_process_leadout(Context &ctx, const TOC &toc, std::fstream &fs_scr
 }
 
 
+void generic_process_leadin(Context &ctx, const TOC &toc, std::fstream &fs_scram, std::fstream &fs_state, std::fstream &fs_subcode, Options &options)
+{
+    if(toc.sessions.empty() || toc.sessions.front().tracks.size() <= 1)
+        return;
+
+    auto &t = toc.sessions.front().tracks.front();
+    if(!(t.control & (uint8_t)ChannelQ::Control::DATA))
+        return;
+
+    int32_t track1_end = toc.sessions.front().tracks[1].lba_start;
+    auto write_offset = track_offset_by_sync(t.lba_start, track1_end, fs_state, fs_scram);
+    if(!write_offset)
+        return;
+
+    int32_t combined_offset = *write_offset + ctx.drive_config.read_offset;
+    if(combined_offset >= 0 || combined_offset < -134 * (int32_t)CD_DATA_SIZE_SAMPLES)
+        return;
+
+    // read from preceding sector up to and including start of first track
+    int32_t read_lba = sample_to_lba(*write_offset, 0) - 1;
+    uint32_t read_count = t.lba_start - read_lba + 1;
+
+    // check if lead-in samples are needed
+    uint32_t sample_index = sample_offset_r2a(lba_to_sample(read_lba, -ctx.drive_config.read_offset));
+    uint32_t samples_count = read_count * CD_DATA_SIZE_SAMPLES;
+    std::vector<State> existing_state(samples_count);
+    read_entry(fs_state, (uint8_t *)existing_state.data(), sizeof(State), sample_index, samples_count, 0, (uint8_t)State::ERROR_SKIP);
+    if(std::none_of(existing_state.begin(), existing_state.end(), [](State s) { return s == State::ERROR_SKIP || s == State::ERROR_C2; }))
+        return;
+
+    auto layout = sector_order_layout(ctx.drive_config.sector_order);
+    std::vector<uint8_t> sector_buffer(CD_RAW_DATA_SIZE * read_count);
+    auto error_field = layout.c2_offset == CD_RAW_DATA_SIZE ? READ_CD_ErrorField::NONE : READ_CD_ErrorField::C2;
+    auto sub_channel = layout.subcode_offset == CD_RAW_DATA_SIZE ? READ_CD_SubChannel::NONE : READ_CD_SubChannel::RAW;
+
+    SPTD::Status status = cmd_read_cd(*ctx.sptd, sector_buffer.data(), CD_RAW_DATA_SIZE, read_lba, read_count, READ_CD_ExpectedSectorType::CD_DA, error_field, sub_channel);
+    if(status.status_code)
+        status = cmd_read_cd(*ctx.sptd, sector_buffer.data(), CD_RAW_DATA_SIZE, read_lba, read_count, READ_CD_ExpectedSectorType::ALL_TYPES, error_field, sub_channel);
+
+    if(status.status_code)
+    {
+        if(options.verbose)
+            LOG("GENERIC: lead-in read failed (LBA: {:6}, sectors: {}, SCSI: {})", read_lba, read_count, SPTD::StatusMessage(status));
+        return;
+    }
+
+    LOG("GENERIC: storing lead-in (LBA: {:6}, sectors: {})", read_lba, read_count);
+
+    std::vector<State> state_buffer(read_count * CD_DATA_SIZE_SAMPLES);
+    std::vector<uint8_t> data_buffer(read_count * CD_DATA_SIZE);
+    std::vector<uint8_t> subcode_buffer(read_count * CD_SUBCODE_SIZE);
+
+    for(uint32_t i = 0; i < read_count; ++i)
+    {
+        auto raw = sector_buffer.data() + layout.size * i;
+
+        std::span<State> sector_state(&state_buffer[i * CD_DATA_SIZE_SAMPLES], CD_DATA_SIZE_SAMPLES);
+        std::span<uint8_t> sector_data(&data_buffer[i * CD_DATA_SIZE], CD_DATA_SIZE);
+        std::span<uint8_t> sector_subcode(&subcode_buffer[i * CD_SUBCODE_SIZE], CD_SUBCODE_SIZE);
+
+        if(layout.c2_offset != CD_RAW_DATA_SIZE)
+        {
+            auto sector_state_c2 = c2_to_state(raw + layout.c2_offset, State::SUCCESS);
+            std::copy(sector_state_c2.begin(), sector_state_c2.end(), sector_state.begin());
+
+            if(options.verbose)
+            {
+                uint32_t c2_bits = c2_bits_count(std::span<const uint8_t>(raw + layout.c2_offset, CD_C2_SIZE));
+                if(c2_bits)
+                    LOGC_R("[LBA: {:6}] C2 error (bits: {:4})", read_lba + i, c2_bits);
+            }
+        }
+        else
+            std::fill(sector_state.begin(), sector_state.end(), State::SUCCESS_C2_OFF);
+
+        if(layout.data_offset != CD_RAW_DATA_SIZE)
+            std::copy(raw + layout.data_offset, raw + layout.data_offset + CD_DATA_SIZE, sector_data.begin());
+
+        if(layout.subcode_offset != CD_RAW_DATA_SIZE)
+            std::copy(raw + layout.subcode_offset, raw + layout.subcode_offset + CD_SUBCODE_SIZE, sector_subcode.begin());
+    }
+
+    store_data(fs_scram, fs_state, data_buffer, state_buffer, lba_to_sample(read_lba, -ctx.drive_config.read_offset));
+    store_subcode(fs_subcode, subcode_buffer, read_lba);
+}
+
+
 export int redumper_dump_extra(Context &ctx, Options &options)
 {
     int exit_code = 0;
@@ -333,6 +420,11 @@ export int redumper_dump_extra(Context &ctx, Options &options)
     {
         if(!options.mediatek_skip_leadout && !is_omnidrive_firmware(ctx.drive_config))
             mediatek_process_leadout(ctx, toc, fs_scram, fs_state, fs_subcode, options);
+    }
+    else if(ctx.drive_config.type == Type::GENERIC)
+    {
+        if(!options.generic_skip_leadin)
+            generic_process_leadin(ctx, toc, fs_scram, fs_state, fs_subcode, options);
     }
 
     return exit_code;

--- a/cd/cd_dump_extra.ixx
+++ b/cd/cd_dump_extra.ixx
@@ -378,7 +378,7 @@ void generic_process_leadin(Context &ctx, const TOC &toc, std::fstream &fs_scram
             {
                 uint32_t c2_bits = c2_bits_count(std::span<const uint8_t>(raw + layout.c2_offset, CD_C2_SIZE));
                 if(c2_bits)
-                    LOGC_R("[LBA: {:6}] C2 error (bits: {:4})", read_lba + i, c2_bits);
+                    LOGC_R("[LBA: {:6}] C2 error (bits: {:4})", read_lba + (int32_t)i, c2_bits);
             }
         }
         else

--- a/options.ixx
+++ b/options.ixx
@@ -63,6 +63,7 @@ export struct Options
     bool plextor_leadin_force_store;
     bool mediatek_skip_leadout;
     int mediatek_leadout_retries;
+    bool generic_skip_leadin;
     bool kreon_partial_ss;
     bool dvd_raw;
     bool bd_raw;
@@ -121,6 +122,7 @@ export struct Options
         , plextor_leadin_force_store(false)
         , mediatek_skip_leadout(false)
         , mediatek_leadout_retries(mediatek_leadout_retries_default)
+        , generic_skip_leadin(false)
         , kreon_partial_ss(false)
         , dvd_raw(false)
         , bd_raw(false)
@@ -282,6 +284,8 @@ export struct Options
                         mediatek_skip_leadout = true;
                     else if(key == "--mediatek-leadout-retries")
                         i_value = &mediatek_leadout_retries;
+                    else if(key == "--generic-skip-leadin")
+                        generic_skip_leadin = true;
                     else if(key == "--kreon-partial-ss")
                         kreon_partial_ss = true;
                     else if(key == "--dvd-raw")
@@ -432,12 +436,12 @@ export struct Options
         LOG("\t--plextor-skip-leadin           \tskip dumping lead-in using negative range");
         LOG("\t--plextor-leadin-retries=VALUE  \tmaximum number of lead-in retries per session (default: {})", plextor_leadin_retries_default);
         LOG("\t--plextor-leadin-force-store    \tstore unverified lead-in");
+        LOG("\t--mediatek-skip-leadout         \tskip extracting lead-out from drive cache");
+        LOG("\t--mediatek-leadout-retries      \tnumber of preceding lead-out sector reads to fill up the cache (default: {})", mediatek_leadout_retries_default);
+        LOG("\t--generic-skip-leadin           \tskip dumping lead-in for negative offset discs on generic drives");
         LOG("\t--kreon-partial-ss              \tget minimal security sector (fixes bad firmware)");
         LOG("\t--dvd-raw                       \tdump raw DVD sectors (OmniDrive)");
         LOG("\t--bd-raw                        \tdump raw BD sectors (OmniDrive)");
-
-        LOG("\t--mediatek-skip-leadout         \tskip extracting lead-out from drive cache");
-        LOG("\t--mediatek-leadout-retries      \tnumber of preceding lead-out sector reads to fill up the cache (default: {})", mediatek_leadout_retries_default);
         LOG("\t--disable-cdtext                \tdisable CD-TEXT reading");
         LOG("");
         LOG("\t(offset)");


### PR DESCRIPTION
Many generic DVD drives (typically with MT18xx chipsets, potentially others) fail to dump (0xBE) the first portion of LBA 0 on CD-ROMs with negative write offsets as the data bleeds into the apparent pregap. This occurs even if the drive has read the pregap sectors (negative LBA) one-by-one, but when reading from negative LBAs the drive read offset is different(?). Because of this missing few samples, redumper fails to split.

Example: A generic drive (e.g. GP60NB60) with +6 read offset with scrambling + DATA_SUB_C2 support attempts to dump a CD-ROM with -12 write offset. The end result is that the combined offset of 6 (+6 + -12) samples is unable to be read, even when dumping with --drive-pregap-start=-135. These missing 6 samples (the sync + subheader of the CDROM) prevent redumper from creating a successful dump.

This PR implements a routine that runs during the dump::extra phase that reads the entire missing first portion that has bled into the apparent lead-in. It does this by reading multiple sectors from an earlier negative LBA. In the case of the missing 6 samples, it needs to recover the data that is stored in-between LBA -1 and 0. So, during dump::extra phase, redumper will read 3 sectors from LBA -2 to 0 and store the samples it did not read during the dump phase. It does this by first checking if the first track is a data track, finding the write offset, checking the combined offset is negative, and also checking whether the state file indicates samples are needing to be read/re-read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added automatic lead-in recovery for generic drives during disc dumping when drive data indicates lead-in reconstruction is needed.
  * Introduced a new CLI option, `--generic-skip-leadin`, to disable this recovery behavior.
  * Updated the command-line help/usage text to include the new option alongside related drive-specific settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->