### PR TITLE
Fix off by one in joliet UCS-2BE to UTF-8 conversion code

### DIFF
--- a/filesystem/iso9660/iso9660_defs.ixx
+++ b/filesystem/iso9660/iso9660_defs.ixx
@@ -382,7 +382,7 @@ std::string identifier_to_string(const uint16_t (&identifier)[N])
         utf16_identifier[i] = endian_swap(identifier[i]);
 
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert("", u"");
-    std::string utf8_identifier = convert.to_bytes(utf16_identifier, &utf16_identifier[N - 1]);
+    std::string utf8_identifier = convert.to_bytes(utf16_identifier, &utf16_identifier[N]);
 
     return trim(utf8_identifier).c_str();
 }


### PR DESCRIPTION
If the identifier happens to be 16 characters long, the last one is omitted by the current conversion code.
According to the [documentation](https://en.cppreference.com/cpp/locale/wstring_convert/to_bytes), the last element from the range passed to the used `to_convert` overload is excluded.
> 4) The wide sequence is the range [first, last).

I assumed it was inclusive when I wrote the original code, this PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ISO 9660 identifier conversion so the final character is included when converting UCS-2BE text to UTF-8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->