### PR TITLE
Update recommended OmniDrive version

### DIFF
--- a/drive.ixx
+++ b/drive.ixx
@@ -474,7 +474,7 @@ export std::string omnidrive_version_string(uint32_t version)
 
 export uint32_t omnidrive_minimum_version()
 {
-    return 0x00010002;
+    return 0x00010004;
 }
 
 

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -809,7 +809,7 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, bool dump)
     std::vector<Range<int32_t>> protection;
 
     auto omnidrive_version = is_omnidrive_firmware(ctx.drive_config);
-    if(*omnidrive_version == 0x00010003)
+    if(omnidrive_version && *omnidrive_version == 0x00010003)
         throw_line("unsupported OmniDrive version for DVD dumping, upgrade to {}", omnidrive_version_string(omnidrive_minimum_version()));
     bool omnidrive_firmware = omnidrive_version != std::nullopt;
     bool kreon_firmware = is_kreon_firmware(ctx.drive_config);

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -808,7 +808,10 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, bool dump)
 
     std::vector<Range<int32_t>> protection;
 
-    bool omnidrive_firmware = is_omnidrive_firmware(ctx.drive_config) != std::nullopt;
+    auto omnidrive_version = is_omnidrive_firmware(ctx.drive_config);
+    if(*omnidrive_version == 0x00010003)
+        throw_line("unsupported OmniDrive version for DVD dumping, upgrade to {}", omnidrive_version_string(omnidrive_minimum_version()));
+    bool omnidrive_firmware = omnidrive_version != std::nullopt;
     bool kreon_firmware = is_kreon_firmware(ctx.drive_config);
     bool kreon_locked = false;
 


### PR DESCRIPTION
v1.0.4 is the latest and recommended version, over the previous v1.0.2
v1.0.3 has an Xbox bug so I have made it refuse to dump DVDs with that version to prevent bad dumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Raised the minimum supported OmniDrive firmware requirement.
  - Updated DVD dumping to validate OmniDrive firmware compatibility before starting.
  - DVD dump now stops immediately and reports an error when encountering a known-incompatible OmniDrive firmware version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->