### PR TITLE
dat and dat_extra split

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,0 @@
-Use C-style casts.
-Use latest C++ standard when generating code.
-Use snake case for stack variables.
-Do not put a space between keyword and (.
-Always add a new line before {.
-Do not add {} to one line if().
-Do not uppercase first letter of a comment except where it's abbrevation.

--- a/cd/cd_split.ixx
+++ b/cd/cd_split.ixx
@@ -287,11 +287,9 @@ bool check_tracks(Context &ctx, const TOC &toc, std::fstream &scm_fs, std::fstre
 }
 
 
-std::vector<std::string> write_tracks(Context &ctx, const TOC &toc, std::fstream &scm_fs, std::fstream &state_fs, std::shared_ptr<const OffsetManager> offset_manager,
-    const std::vector<Range<int32_t>> &protection, bool dreamcast, const Options &options)
+void write_tracks(Context &ctx, const TOC &toc, std::fstream &scm_fs, std::fstream &state_fs, std::shared_ptr<const OffsetManager> offset_manager, const std::vector<Range<int32_t>> &protection,
+    bool dreamcast, const Options &options)
 {
-    std::vector<std::string> xml_lines;
-
     Scrambler scrambler;
     std::vector<uint8_t> sector(CD_DATA_SIZE);
     std::vector<State> state(CD_DATA_SIZE_SAMPLES);
@@ -416,11 +414,12 @@ std::vector<std::string> write_tracks(Context &ctx, const TOC &toc, std::fstream
                 //                LOG("debug: scram offset: {:08X}", debug_get_scram_offset(d.first, write_offset));
             }
 
-            xml_lines.emplace_back(rom_entry.xmlLine());
+            if(lilo)
+                ctx.dat_extra.emplace_back(rom_entry.xmlLine());
+            else
+                ctx.dat.emplace_back(rom_entry.xmlLine());
         }
     }
-
-    return xml_lines;
 }
 
 
@@ -1439,7 +1438,7 @@ export void redumper_split_cd(Context &ctx, Options &options)
 
     // write tracks
     LOG("writing tracks");
-    ctx.dat = write_tracks(ctx, toc, scm_fs, state_fs, offset_manager, protection, dreamcast, options);
+    write_tracks(ctx, toc, scm_fs, state_fs, offset_manager, protection, dreamcast, options);
     LOG("done");
     LOG("");
 

--- a/common.ixx
+++ b/common.ixx
@@ -70,7 +70,8 @@ export struct Context
     std::optional<bool> protection_trim;
     RefineCache refine_cache;
     std::optional<bool> refine;
-    std::optional<std::vector<std::string>> dat;
+    std::vector<std::string> dat;
+    std::vector<std::string> dat_extra;
 };
 
 

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -1393,7 +1393,7 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, bool dump)
         signal.raiseDefault();
 
     if(rom_update)
-        ctx.dat = std::vector<std::string>(1, rom_entry.xmlLine());
+        ctx.dat.emplace_back(rom_entry.xmlLine());
 
     return errors.scsi || errors.edc;
 }

--- a/dvd/dvd_split.ixx
+++ b/dvd/dvd_split.ixx
@@ -59,8 +59,7 @@ void generate_extra_xbox(Context &ctx, Options &options)
 
                 ROMEntry dmi_rom_entry(dmi_path.filename().string());
                 dmi_rom_entry.update(manufacturer.data(), FORM1_DATA_SIZE);
-                if(ctx.dat.has_value())
-                    ctx.dat->push_back(dmi_rom_entry.xmlLine());
+                ctx.dat_extra.emplace_back(dmi_rom_entry.xmlLine());
             }
             else
             {
@@ -88,8 +87,7 @@ void generate_extra_xbox(Context &ctx, Options &options)
 
                 ROMEntry pfi_rom_entry(pfi_path.filename().string());
                 pfi_rom_entry.update(physical.data(), FORM1_DATA_SIZE);
-                if(ctx.dat.has_value())
-                    ctx.dat->push_back(pfi_rom_entry.xmlLine());
+                ctx.dat_extra.emplace_back(pfi_rom_entry.xmlLine());
             }
             else
             {
@@ -114,8 +112,7 @@ void generate_extra_xbox(Context &ctx, Options &options)
 
             ROMEntry ss_rom_entry(ss_path.filename().string());
             ss_rom_entry.update(security.data(), FORM1_DATA_SIZE);
-            if(ctx.dat.has_value())
-                ctx.dat->push_back(ss_rom_entry.xmlLine());
+            ctx.dat_extra.emplace_back(ss_rom_entry.xmlLine());
         }
         else
         {

--- a/hash.ixx
+++ b/hash.ixx
@@ -1,4 +1,5 @@
 module;
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <list>
@@ -21,6 +22,31 @@ import utils.misc;
 namespace gpsxre
 {
 
+ROMEntry calculate_file_hash(const std::filesystem::path &f)
+{
+    ROMEntry rom_entry(f.filename().string());
+
+    std::fstream fs(f, std::fstream::in | std::fstream::binary);
+    if(!fs.is_open())
+        throw_line("unable to open file ({})", f.filename().string());
+
+    std::vector<uint8_t> data(CHUNK_1MB); // 1Mb chunk
+    batch_process_range<uint64_t>(std::pair(0, std::filesystem::file_size(f)), data.size(),
+        [&](uint64_t offset, uint64_t size) -> bool
+        {
+            fs.read((char *)data.data(), size);
+            if(fs.fail())
+                throw_line("read failed ({})", f.filename().string());
+
+            rom_entry.update(data.data(), size);
+
+            return false;
+        });
+
+    return rom_entry;
+}
+
+
 void progress_output(uint64_t byte, uint64_t bytes_count)
 {
     char animation = byte == bytes_count ? '*' : spinner_animation();
@@ -33,10 +59,10 @@ export int redumper_hash(Context &ctx, Options &options)
 {
     int exit_code = 0;
 
-    if(!ctx.dat)
-    {
-        auto image_prefix = (std::filesystem::path(options.image_path) / options.image_name).string();
+    auto image_prefix = (std::filesystem::path(options.image_path) / options.image_name).string();
 
+    if(ctx.dat.empty())
+    {
         std::vector<std::filesystem::path> files;
         if(std::filesystem::exists(image_prefix + ".cue"))
         {
@@ -46,57 +72,26 @@ export int redumper_hash(Context &ctx, Options &options)
         else if(std::filesystem::exists(image_prefix + ".iso"))
         {
             files.push_back(image_prefix + ".iso");
-
-            // hash xbox extras
-            if(std::filesystem::exists(image_prefix + ".dmi"))
-                files.push_back(image_prefix + ".dmi");
-            if(std::filesystem::exists(image_prefix + ".pfi"))
-                files.push_back(image_prefix + ".pfi");
-            if(std::filesystem::exists(image_prefix + ".ss"))
-                files.push_back(image_prefix + ".ss");
         }
         else
             throw_line("image file not found");
 
         if(!files.empty())
         {
-            uint64_t byte = 0;
+            uint64_t bytes = 0;
             uint64_t bytes_count = 0;
             for(auto f : files)
                 bytes_count += std::filesystem::file_size(f);
 
-            std::vector<std::string> dat;
-
-            std::vector<uint8_t> sector(CD_DATA_SIZE);
             for(auto f : files)
             {
-                std::fstream fs(f, std::fstream::in | std::fstream::binary);
-                if(!fs.is_open())
-                    throw_line("unable to open file ({})", f.filename().string());
+                progress_output(bytes, bytes_count);
 
-                ROMEntry rom_entry(f.filename().string());
+                auto rom_entry = calculate_file_hash(f);
+                bytes += rom_entry.getSize();
 
-                std::vector<uint8_t> data(CHUNK_1MB); // 1Mb chunk
-                batch_process_range<uint64_t>(std::pair(0, std::filesystem::file_size(f)), data.size(),
-                    [&](uint64_t offset, uint64_t size) -> bool
-                    {
-                        progress_output(byte, bytes_count);
-
-                        fs.read((char *)data.data(), size);
-                        if(fs.fail())
-                            throw_line("read failed ({})", f.filename().string());
-
-                        rom_entry.update(data.data(), size);
-
-                        byte += size;
-
-                        return false;
-                    });
-
-                dat.push_back(rom_entry.xmlLine());
+                ctx.dat.push_back(rom_entry.xmlLine());
             }
-
-            ctx.dat = dat;
 
             progress_output(bytes_count, bytes_count);
             LOG("");
@@ -104,10 +99,57 @@ export int redumper_hash(Context &ctx, Options &options)
         }
     }
 
-    if(ctx.dat)
+    if(ctx.dat_extra.empty())
+    {
+        std::list<std::filesystem::path> files;
+
+        // hash CD extras
+        if(std::filesystem::exists(image_prefix + ".cue"))
+        {
+            auto image_path = std::filesystem::path(options.image_path);
+            if(image_path.empty())
+                image_path = ".";
+
+            auto cue_entries = cue_get_entries(image_prefix + ".cue");
+            auto track_prefix = std::filesystem::path(image_prefix).filename().string() + " (Track ";
+
+            for(auto const &entry : std::filesystem::directory_iterator(image_path))
+            {
+                auto filename = entry.path().filename().string();
+                if(!filename.starts_with(track_prefix) || !filename.ends_with(").bin"))
+                    continue;
+
+                if(std::none_of(cue_entries.begin(), cue_entries.end(), [&](auto const &t) { return std::filesystem::path(t.first) == filename; }))
+                    files.push_back(entry.path());
+            }
+        }
+        // hash xbox extras
+        else if(std::filesystem::exists(image_prefix + ".iso"))
+        {
+            if(std::filesystem::exists(image_prefix + ".dmi"))
+                files.push_back(image_prefix + ".dmi");
+            if(std::filesystem::exists(image_prefix + ".pfi"))
+                files.push_back(image_prefix + ".pfi");
+            if(std::filesystem::exists(image_prefix + ".ss"))
+                files.push_back(image_prefix + ".ss");
+        }
+
+        files.sort();
+        for(auto f : files)
+            ctx.dat_extra.push_back(calculate_file_hash(f).xmlLine());
+    }
+
+    if(!ctx.dat.empty())
     {
         LOG("dat:");
-        for(auto l : *ctx.dat)
+        for(auto l : ctx.dat)
+            LOG("{}", l);
+    }
+
+    if(!ctx.dat_extra.empty())
+    {
+        LOG("dat (extra):");
+        for(auto l : ctx.dat_extra)
             LOG("{}", l);
     }
 

--- a/rom_entry.ixx
+++ b/rom_entry.ixx
@@ -40,6 +40,12 @@ public:
     }
 
 
+    uint64_t getSize() const
+    {
+        return _size;
+    }
+
+
     std::string xmlLine()
     {
         // do it only once because final() for MD5/SHA-1 modifies state


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating separate metadata output for supplementary disc data.
  * Improved hashing progress reporting with clearer per-file updates.
  * Added file-size access for generated ROM metadata.

* **Bug Fixes**
  * Preserved existing metadata while adding entries for DVD and disc images.
  * Improved handling of Xbox supplementary metadata and disc track entries.
  * Added more reliable error handling when files cannot be opened or read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->