### PR TITLE
Fix missing include

### DIFF
--- a/filesystem/udf/udf_browser.ixx
+++ b/filesystem/udf/udf_browser.ixx
@@ -1,4 +1,5 @@
 module;
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
```
FAILED: [code=1] CMakeFiles/redumper.dir/filesystem/udf/udf_browser.ixx.o CMakeFiles/redumper.dir/filesystem.udf-browser.pcm 
/usr/bin/clang++ -DREDUMPER_VERSION_BUILD=\"b738.fc44\" -I/builddir/build/BUILD/redumper-b738-build/redumper-b738 -I/builddir/build/BUILD/redumper-b738-build/redumper-b738/redhat-linux-build -I/builddir/bu
ild/BUILD/redumper-b738-build/redumper-b738/utils -O2 -flto=thin -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D
_GLIBCXX_ASSERTIONS --config=/usr/lib/rpm/redhat/redhat-hardened-clang.cfg -fstack-protector-strong   -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection
 -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -std=gnu++20 -MD -MT CMakeFiles/redumper.dir/filesystem/udf/udf_browser.ixx.o -MF CMakeFiles/redumper.dir/filesystem/udf/udf_brow
ser.ixx.o.d @CMakeFiles/redumper.dir/filesystem/udf/udf_browser.ixx.o.modmap -o CMakeFiles/redumper.dir/filesystem/udf/udf_browser.ixx.o -c /builddir/build/BUILD/redumper-b738-build/redumper-b738/filesyste
m/udf/udf_browser.ixx
/builddir/build/BUILD/redumper-b738-build/redumper-b738/filesystem/udf/udf_browser.ixx:37:32: error: missing '#include <bits/stdint-uintn.h>'; 'uint32_t' must be declared before it is used
   37 |     const static std::optional<uint32_t> findDescriptorOffset(DataReader *data_reader, ExtentDescriptor main_vds, TagIdentifier type)
      |                                ^
/usr/include/bits/stdint-uintn.h:26:20: note: declaration here is not visible
   26 | typedef __uint32_t uint32_t;
      |                    ^
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability for the browser module by ensuring required integer types are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->