### PR TITLE
Find root directory on UDF 2.50

### DIFF
--- a/filesystem/udf/udf_browser.ixx
+++ b/filesystem/udf/udf_browser.ixx
@@ -3,6 +3,8 @@ module;
 #include <cstring>
 #include <memory>
 #include <optional>
+#include <string_view>
+#include <variant>
 #include <vector>
 
 export module filesystem.udf:browser;
@@ -57,7 +59,7 @@ public:
         return {};
     }
 
-    static std::shared_ptr<udf::FileEntry> rootDirectory(DataReader *data_reader)
+    static std::variant<std::shared_ptr<udf::FileEntry>, std::shared_ptr<udf::ExtendedFileEntry>> rootDirectory(DataReader *data_reader)
     {
         // Try and find the AVDP so we can look through the volume descriptor sequence.
         auto const avdp = findAnchorVolumeDescriptorPointer(data_reader);
@@ -74,6 +76,10 @@ public:
             data_reader->read(partition_data.data(), partition_offset.value(), 1);
             struct udf::PartitionDescriptor partition_descriptor = (udf::PartitionDescriptor &)partition_data[0];
 
+            // For the moment, we're just assuming that partitions are inserted into this in order.
+            std::vector<uint32_t> partition_starting_locations;
+            partition_starting_locations.push_back(partition_descriptor.partition_starting_location);
+
             // Search for the logical volume descriptor. This contains the extent of the file set descriptor.
             auto lvd_offset = findDescriptorOffset(data_reader, avdp.value().main_vds, udf::TagIdentifier::LOGICAL);
             if(!lvd_offset.has_value())
@@ -84,26 +90,67 @@ public:
             data_reader->read(lvd_data.data(), lvd_offset.value(), 1);
             struct udf::LogicalVolumeDescriptor logical_volume_descriptor = (udf::LogicalVolumeDescriptor &)lvd_data[0];
 
+            // Parse the partition maps in the logical volume descriptor to find the metadata partition map, if it's present.
+            auto partition_map_offset = sizeof(udf::LogicalVolumeDescriptor);
+            for(int i = 0; i < logical_volume_descriptor.number_of_partition_maps; i++)
+            {
+                struct udf::partition_map_header partition_map_header = (udf::partition_map_header &)lvd_data[partition_map_offset];
+
+                if(2 == partition_map_header.partition_map_type)
+                {
+                    struct udf::partition_map_type_2_header partition_map_type_2_header = (udf::partition_map_type_2_header &)lvd_data[partition_map_offset];
+
+                    // While we know the identifier is only 23 bytes long, if we don't wrap it in a bounded string view the comparison will continue reading after it until it finds a null terminator.
+                    if(std::string_view(partition_map_type_2_header.partition_type_identifier.identifier, 23) == PARTITION_TYPE_ID_METADATA)
+                    {
+                        // If we've found the metadata partition, parse it as an extended file entry and use the position of the first allocation descriptor to determine the start of partition 1.
+                        struct udf::metadata_partition_map metadata_partition_map = (udf::metadata_partition_map &)lvd_data[partition_map_offset];
+
+                        std::vector<uint8_t> metadata_file_data(FORM1_DATA_SIZE);
+                        data_reader->read(metadata_file_data.data(), partition_starting_locations[metadata_partition_map.partition_number] + metadata_partition_map.metadata_file_location, 1);
+                        struct udf::ExtendedFileEntry metadata_file = (udf::ExtendedFileEntry &)metadata_file_data[0];
+
+                        // This isn't particularly well explained in the spec, so this behavior comes from libudfread.
+                        struct udf::short_ad metadata_file_ad = (udf::short_ad &)metadata_file_data[sizeof(udf::ExtendedFileEntry) + metadata_file.length_of_extended_attributes];
+                        partition_starting_locations.push_back(partition_starting_locations[0] + metadata_file_ad.extent_position);
+                    }
+                }
+                partition_map_offset += partition_map_header.partition_map_length;
+            }
+
             auto const &file_set_descriptor_extent = (udf::long_ad &)logical_volume_descriptor.logical_volume_contents_use;
 
             // If we have the partition the file set descriptor is found in, parse it to find the root directory ICB extent.
-            if(partition_descriptor.partition_number == file_set_descriptor_extent.extent_location.partition_reference_number)
+            if(partition_starting_locations.size() - 1 >= file_set_descriptor_extent.extent_location.partition_reference_number)
             {
                 std::vector<uint8_t> fsd_data(FORM1_DATA_SIZE);
-                data_reader->read(fsd_data.data(), partition_descriptor.partition_starting_location + file_set_descriptor_extent.extent_location.logical_block_number, 1);
+                data_reader->read(fsd_data.data(),
+                    partition_starting_locations[file_set_descriptor_extent.extent_location.partition_reference_number] + file_set_descriptor_extent.extent_location.logical_block_number, 1);
                 auto const &file_set_descriptor = (udf::FileSetDescriptor &)fsd_data[0];
 
                 auto const &root_directory_icb_extent = file_set_descriptor.root_directory_icb;
 
                 // If we have the partition the root directory is in, read and return it.
-                if(partition_descriptor.partition_number == root_directory_icb_extent.extent_location.partition_reference_number)
+                if(partition_starting_locations.size() - 1 >= root_directory_icb_extent.extent_location.partition_reference_number)
                 {
                     std::vector<uint8_t> root_directory_data(FORM1_DATA_SIZE);
-                    data_reader->read(root_directory_data.data(), partition_descriptor.partition_starting_location + root_directory_icb_extent.extent_location.logical_block_number, 1);
+                    data_reader->read(root_directory_data.data(),
+                        partition_starting_locations[root_directory_icb_extent.extent_location.partition_reference_number] + root_directory_icb_extent.extent_location.logical_block_number, 1);
 
-                    auto root_directory_file_entry = std::shared_ptr<udf::FileEntry>(new udf::FileEntry());
-                    std::memcpy(root_directory_file_entry.get(), root_directory_data.data(), sizeof(udf::FileEntry));
-                    return root_directory_file_entry;
+                    auto const &tag = (udf::DescriptorTag &)root_directory_data[0];
+                    if(tag.tag_identifier == udf::TagIdentifier::FILE_ENTRY)
+                    {
+                        auto root_directory_file_entry = std::shared_ptr<udf::FileEntry>(new udf::FileEntry());
+                        std::memcpy(root_directory_file_entry.get(), root_directory_data.data(), sizeof(udf::FileEntry));
+                        return root_directory_file_entry;
+                    }
+                    else if(tag.tag_identifier == udf::TagIdentifier::EXTENDED_FILE_ENTRY)
+                    {
+                        auto root_directory_file_entry = std::shared_ptr<udf::ExtendedFileEntry>(new udf::ExtendedFileEntry());
+                        std::memcpy(root_directory_file_entry.get(), root_directory_data.data(), sizeof(udf::ExtendedFileEntry));
+
+                        return root_directory_file_entry;
+                    }
                 }
             }
         }

--- a/filesystem/udf/udf_defs.ixx
+++ b/filesystem/udf/udf_defs.ixx
@@ -18,6 +18,9 @@ constexpr std::string_view DESCRIPTOR_ID_NSR2 = "NSR02";
 constexpr std::string_view DESCRIPTOR_ID_NSR3 = "NSR03";
 constexpr std::string_view DESCRIPTOR_ID_TEA = "TEA01";
 const std::set<std::string_view> DESCRIPTORS = { DESCRIPTOR_ID_BEA, DESCRIPTOR_ID_BOOT2, DESCRIPTOR_ID_CDW, DESCRIPTOR_ID_NSR2, DESCRIPTOR_ID_NSR3, DESCRIPTOR_ID_TEA };
+constexpr std::string_view PARTITION_TYPE_ID_VIRTUAL = "*UDF Virtual Partition";
+constexpr std::string_view PARTITION_TYPE_ID_SPARABLE = "*UDF Sparable Partition";
+constexpr std::string_view PARTITION_TYPE_ID_METADATA = "*UDF Metadata Partition";
 
 
 enum class TagIdentifier : uint16_t
@@ -31,9 +34,14 @@ enum class TagIdentifier : uint16_t
     LOGICAL,
     UNALLOCATED_SPACE,
     TERMINATING,
-    LOGICAL_INTEGRITY
-};
+    LOGICAL_INTEGRITY,
 
+    FILE_SET = 256,
+    FILE_IDENTIFIER = 257,
+    ALLOCATION_EXTENT = 258,
+    FILE_ENTRY = 261,
+    EXTENDED_FILE_ENTRY = 266
+};
 
 #pragma pack(push, 1)
 struct DescriptorTag
@@ -84,6 +92,12 @@ struct charspec
     uint8_t character_set_info[63];
 };
 
+struct short_ad
+{
+    uint32_t extent_length;
+    uint32_t extent_position;
+};
+
 struct lb_addr
 {
     uint32_t logical_block_number;
@@ -100,8 +114,39 @@ struct long_ad
 struct EntityID
 {
     uint8_t flags;
-    uint8_t identifier[23];
-    uint8_t identifier_suffix[8];
+    char identifier[23];
+    char identifier_suffix[8];
+};
+
+struct partition_map_header
+{
+    uint8_t partition_map_type;
+    uint8_t partition_map_length;
+};
+
+struct partition_map_type_1 : partition_map_header
+{
+    uint16_t volume_sequence_number;
+    uint16_t partition_number;
+};
+
+struct partition_map_type_2_header : partition_map_header
+{
+    uint8_t reserved_1[2];
+    EntityID partition_type_identifier;
+};
+
+struct metadata_partition_map : partition_map_type_2_header
+{
+    uint16_t volume_sequence_number;
+    uint16_t partition_number;
+    uint32_t metadata_file_location;
+    uint32_t metadata_mirror_file_location;
+    uint32_t metadata_bitmap_file_location;
+    uint32_t allocation_unit_size;
+    uint16_t alignment_unit_size;
+    uint8_t flags;
+    uint8_t reserved_2[5];
 };
 
 struct LogicalVolumeDescriptor
@@ -174,6 +219,35 @@ struct FileEntry
     timestamp attribute_time;
     uint32_t checkpoint;
     long_ad extended_attribute_icb;
+    EntityID implementation_identifier;
+    uint64_t unique_id;
+    uint32_t length_of_extended_attributes;
+    uint32_t length_of_allocation_descriptors;
+    uint8_t extended_attributes_and_allocation_descriptors[];
+};
+
+struct ExtendedFileEntry
+{
+    DescriptorTag descriptor_tag;
+    icbtag icb_tag;
+    uint32_t uid;
+    uint32_t gid;
+    uint32_t permissions;
+    uint16_t file_link_count;
+    uint8_t record_format;
+    uint8_t record_display_attributes;
+    uint32_t record_length;
+    uint64_t information_length;
+    uint64_t object_size;
+    uint64_t logical_blocks_recorded;
+    timestamp access_time;
+    timestamp modification_time;
+    timestamp creation_time;
+    timestamp attribute_time;
+    uint32_t checkpoint;
+    uint32_t reserved;
+    long_ad extended_attribute_icb;
+    long_ad stream_directory_icb;
     EntityID implementation_identifier;
     uint64_t unique_id;
     uint32_t length_of_extended_attributes;


### PR DESCRIPTION
Kind of a mess to figure out, slightly less of a mess to implement.

This just extends the functionality of #403 to cover UDF 2.50 images (i.e. the kind that aren't just backwards compatible ISO9660). Another PR will be needed to support actually reading files and traversing directories and so on.

As before, this is tested and working but because it isn't ready to be directly used I haven't added the temporary command I used to test it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved UDF filesystem support for virtual, sparable, and metadata partitions.
  * Added support for extended file entries and additional UDF file and directory descriptors.
  * Enhanced partition tracking to locate file sets and root directories correctly across supported partition types.

* **Bug Fixes**
  * Improved root-directory detection and handling for discs using extended UDF metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->