### PR TITLE
Add LG-Based ASUS SDRW-8D2S-U (LG GP75N inside)

### DIFF
--- a/drive.ixx
+++ b/drive.ixx
@@ -214,6 +214,7 @@ static const std::vector<DriveConfig> DRIVE_DATABASE =
     { "PLEXTOR" , "CD-R PX-W8220T"   , ""    , "", "", +355, 294,  -75, ReadMethod::D8, SectorOrder::DATA_SUB   , Type::PLEXTOR  },
     { "PLEXTOR" , "CD-R PX-W8432T"   , ""    , "", "", +355, 294,  -75, ReadMethod::D8, SectorOrder::DATA_SUB   , Type::PLEXTOR  },
     // OTHER
+    { "ASUS"    , "SDRW-08D2S-U"     , "A812", "", "",    +6,  0,    0, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // internal model: LG GP75N
     { "ASUS"    , "SDRW-08D2S-U"     , "B901", "", "",    +6,  0, -135, ReadMethod::BE, SectorOrder::DATA_SUB_C2, Type::GENERIC  }, // internal model: DU-8A6NH11B
     { "ASUS"    , "SDRW-08U9M-U"     , "A112", "", "",    +6,  0, -135, ReadMethod::BE, SectorOrder::DATA_SUB_C2, Type::GENERIC  },
     { "Lite-On" , "LTN483S 48x Max"  , "PD03", "", "", -1164,  0,    0, ReadMethod::BE, SectorOrder::DATA_C2    , Type::GENERIC  },

--- a/offsets.ixx
+++ b/offsets.ixx
@@ -313,6 +313,7 @@ export const DriveReadOffset DRIVE_READ_OFFSETS[] = {
     { "ASUS",     "SDR-08B1-U A",     +6    },
     { "ASUS",     "SDR-08B1-U",       +6    },
     { "ASUS",     "SDRW-0806T-D",     +704  },
+    { "ASUS",     "SDRW-08D2S-U",     +6    },
     { "ASUS",     "SDRW-08D3S-U",     +6    },
     { "ASUS",     "SDRW-08D6S-U",     +6    },
     { "ASUS",     "SDRW-08U1MT",      +6    },

--- a/offsets.ixx
+++ b/offsets.ixx
@@ -313,7 +313,6 @@ export const DriveReadOffset DRIVE_READ_OFFSETS[] = {
     { "ASUS",     "SDR-08B1-U A",     +6    },
     { "ASUS",     "SDR-08B1-U",       +6    },
     { "ASUS",     "SDRW-0806T-D",     +704  },
-    { "ASUS",     "SDRW-08D2S-U",     +6    },
     { "ASUS",     "SDRW-08D3S-U",     +6    },
     { "ASUS",     "SDRW-08D6S-U",     +6    },
     { "ASUS",     "SDRW-08U1MT",      +6    },


### PR DESCRIPTION
Newer ASUS SDRW-8D2S-U are actually an LG GP75N inside the enclosure with ASUS firmware. These have a +6 offset not listed in the AccurateRip but can confirm as:
1. it is the same hardware platform LG is using along their models (GP60NB50, GP65NB60, GP96, GPM2, etc)
2. using 3 discs in EAC confirms it is +6 and accuraterip confirms the tracks are ripped accurately.

It seems this drive was purged because previous models used a Samsung drive inside, but the LG is MediaTek-based (MT1887) hence the +6 offset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ASUS SDRW-08D2S-U firmware A812 with the internal LG GP75N drive model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->