### PR TITLE
Fix UDF trimming for BD-R dumps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ target_sources(redumper
     "filesystem/udf/udf.ixx"
     "filesystem/udf/udf_browser.ixx"
     "filesystem/udf/udf_defs.ixx"
+    "filesystem/udf/udf_size.ixx"
     "hash/block_hasher.ixx"
     "hash/md5.ixx"
     "hash/sha1.ixx"

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -26,6 +26,7 @@ import dvd.nintendo;
 import dvd.xbox;
 import filesystem.iso9660;
 import filesystem.udf;
+import filesystem.udf_size;
 import interval_set;
 import options;
 import range;
@@ -415,6 +416,9 @@ struct FilesystemContext
     bool search = true;
     bool udf = false;
     std::vector<std::pair<uint32_t, uint32_t>> udf_vds;
+    uint32_t udf_partition_end = 0;
+    std::optional<udf::ExtentDescriptor> udf_reserve_vds;
+    std::optional<uint32_t> udf_trailing_avdp_lba;
 };
 
 
@@ -458,10 +462,11 @@ std::optional<std::pair<uint32_t, bool>> filesystem_search_size(FilesystemContex
                 // ordering is intentional
                 ctx.udf_vds.emplace_back(avdp.reserve_vds.location, scale_up(avdp.reserve_vds.length, FORM1_DATA_SIZE));
                 ctx.udf_vds.emplace_back(avdp.main_vds.location, scale_up(avdp.main_vds.length, FORM1_DATA_SIZE));
+                ctx.udf_reserve_vds = avdp.reserve_vds;
             }
         }
 
-        if(!ctx.udf_vds.empty() && ctx.udf_vds.back().first + ctx.udf_vds.back().second <= lba)
+        if(!ctx.udf_vds.empty() && (uint64_t)ctx.udf_vds.back().first + ctx.udf_vds.back().second <= lba)
         {
             std::vector<uint8_t> sector_data_file(ctx.udf_vds.back().second * FORM1_DATA_SIZE);
             std::vector<State> sector_state_file(ctx.udf_vds.back().second);
@@ -482,20 +487,41 @@ std::optional<std::pair<uint32_t, bool>> filesystem_search_size(FilesystemContex
                     {
                         auto const &partition = (udf::PartitionDescriptor &)sector_data_file[i * FORM1_DATA_SIZE];
 
-                        sectors_count = std::max(sectors_count, partition.partition_starting_location + partition.partition_length);
+                        uint64_t partition_end = (uint64_t)partition.partition_starting_location + partition.partition_length;
+                        if(partition_end <= std::numeric_limits<uint32_t>::max())
+                            sectors_count = std::max(sectors_count, (uint32_t)partition_end);
                     }
                     else if(tag.tag_identifier == udf::TagIdentifier::TERMINATING)
                         break;
                 }
 
-                ctx.udf_vds.clear();
+                ctx.udf_vds.pop_back();
+                ctx.udf_partition_end = std::max(ctx.udf_partition_end, sectors_count);
 
-                if(sectors_count)
-                    // account for trailing AVDP
-                    ss = std::make_pair(sectors_count + 1, true);
+                auto reserve_vds = ctx.udf_reserve_vds.value_or(udf::ExtentDescriptor{});
+                ctx.udf_trailing_avdp_lba = udf::get_trailing_avdp_lba(ctx.udf_partition_end, reserve_vds.location, reserve_vds.length, FORM1_DATA_SIZE);
             }
             else
                 ctx.udf_vds.pop_back();
+        }
+
+        if(ctx.udf_trailing_avdp_lba && lba >= *ctx.udf_trailing_avdp_lba)
+        {
+            auto const &tag = (udf::DescriptorTag &)data[0];
+
+            if(udf::is_trailing_avdp_search_lba(lba, *ctx.udf_trailing_avdp_lba))
+            {
+                if(tag.tag_identifier == udf::TagIdentifier::ANCHOR_POINTER && tag.tag_location == lba && lba < std::numeric_limits<uint32_t>::max())
+                {
+                    ss = std::make_pair(lba + 1, true);
+                    ctx.udf = false;
+                }
+            }
+            else
+            {
+                LOG("warning: UDF trailing AVDP not found after reserve VDS");
+                ctx.udf = false;
+            }
         }
     }
 

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -416,9 +416,7 @@ struct FilesystemContext
     bool search = true;
     bool udf = false;
     std::vector<std::pair<uint32_t, uint32_t>> udf_vds;
-    uint32_t udf_partition_end = 0;
     std::optional<udf::ExtentDescriptor> udf_reserve_vds;
-    std::optional<uint32_t> udf_trailing_avdp_lba;
 };
 
 
@@ -453,19 +451,22 @@ std::optional<std::pair<uint32_t, bool>> filesystem_search_size(FilesystemContex
         }
     }
 
+    // A valid primary AVDP is sufficient to detect UDF even when the volume
+    // recognition sequence is absent or not recognized.
+    if(lba == udf::AVDP_PRIMARY_LBA)
+    {
+        if(auto const &avdp = (udf::AnchorVolumeDescriptorPointer &)data[0]; avdp.descriptor_tag.tag_identifier == udf::TagIdentifier::ANCHOR_POINTER && avdp.descriptor_tag.tag_location == lba)
+        {
+            ctx.udf = true;
+            // ordering is intentional
+            ctx.udf_vds.emplace_back(avdp.reserve_vds.location, scale_up(avdp.reserve_vds.length, FORM1_DATA_SIZE));
+            ctx.udf_vds.emplace_back(avdp.main_vds.location, scale_up(avdp.main_vds.length, FORM1_DATA_SIZE));
+            ctx.udf_reserve_vds = avdp.reserve_vds;
+        }
+    }
+
     if(ctx.udf)
     {
-        if(lba == udf::AVDP_PRIMARY_LBA)
-        {
-            if(auto const &avdp = (udf::AnchorVolumeDescriptorPointer &)data[0]; avdp.descriptor_tag.tag_identifier == udf::TagIdentifier::ANCHOR_POINTER)
-            {
-                // ordering is intentional
-                ctx.udf_vds.emplace_back(avdp.reserve_vds.location, scale_up(avdp.reserve_vds.length, FORM1_DATA_SIZE));
-                ctx.udf_vds.emplace_back(avdp.main_vds.location, scale_up(avdp.main_vds.length, FORM1_DATA_SIZE));
-                ctx.udf_reserve_vds = avdp.reserve_vds;
-            }
-        }
-
         if(!ctx.udf_vds.empty() && (uint64_t)ctx.udf_vds.back().first + ctx.udf_vds.back().second <= lba)
         {
             std::vector<uint8_t> sector_data_file(ctx.udf_vds.back().second * FORM1_DATA_SIZE);
@@ -495,33 +496,17 @@ std::optional<std::pair<uint32_t, bool>> filesystem_search_size(FilesystemContex
                         break;
                 }
 
-                ctx.udf_vds.pop_back();
-                ctx.udf_partition_end = std::max(ctx.udf_partition_end, sectors_count);
+                ctx.udf_vds.clear();
 
                 auto reserve_vds = ctx.udf_reserve_vds.value_or(udf::ExtentDescriptor{});
-                ctx.udf_trailing_avdp_lba = udf::get_trailing_avdp_lba(ctx.udf_partition_end, reserve_vds.location, reserve_vds.length, FORM1_DATA_SIZE);
-            }
-            else
-                ctx.udf_vds.pop_back();
-        }
-
-        if(ctx.udf_trailing_avdp_lba && lba >= *ctx.udf_trailing_avdp_lba)
-        {
-            auto const &tag = (udf::DescriptorTag &)data[0];
-
-            if(udf::is_trailing_avdp_search_lba(lba, *ctx.udf_trailing_avdp_lba))
-            {
-                if(tag.tag_identifier == udf::TagIdentifier::ANCHOR_POINTER && tag.tag_location == lba && lba < std::numeric_limits<uint32_t>::max())
+                if(auto volume_sectors_count = udf::get_volume_sectors_count(sectors_count, reserve_vds.location, reserve_vds.length, FORM1_DATA_SIZE); volume_sectors_count)
                 {
-                    ss = std::make_pair(lba + 1, true);
+                    ss = std::make_pair(*volume_sectors_count, true);
                     ctx.udf = false;
                 }
             }
             else
-            {
-                LOG("warning: UDF trailing AVDP not found after reserve VDS");
-                ctx.udf = false;
-            }
+                ctx.udf_vds.pop_back();
         }
     }
 

--- a/filesystem/udf/udf_size.ixx
+++ b/filesystem/udf/udf_size.ixx
@@ -1,0 +1,39 @@
+module;
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+export module filesystem.udf_size;
+
+
+
+export namespace gpsxre::udf
+{
+
+constexpr uint32_t TRAILING_AVDP_SEARCH_SECTORS = 256;
+
+
+constexpr std::optional<uint32_t> get_trailing_avdp_lba(uint32_t partition_end, uint32_t reserve_vds_location, uint32_t reserve_vds_length, uint32_t sector_size)
+{
+    if(!partition_end || !sector_size)
+        return std::nullopt;
+
+    uint64_t reserve_length = ((uint64_t)reserve_vds_length + sector_size - 1) / sector_size;
+    uint64_t reserve_end = reserve_length ? (uint64_t)reserve_vds_location + reserve_length : 0;
+    uint64_t metadata_end = std::max<uint64_t>(partition_end, reserve_end);
+
+    // The sector at metadata_end is the first possible location of the trailing AVDP.
+    if(metadata_end >= std::numeric_limits<uint32_t>::max())
+        return std::nullopt;
+
+    return metadata_end;
+}
+
+
+constexpr bool is_trailing_avdp_search_lba(uint32_t lba, uint32_t expected_lba)
+{
+    return lba >= expected_lba && (uint64_t)lba < (uint64_t)expected_lba + TRAILING_AVDP_SEARCH_SECTORS;
+}
+
+}

--- a/filesystem/udf/udf_size.ixx
+++ b/filesystem/udf/udf_size.ixx
@@ -11,10 +11,7 @@ export module filesystem.udf_size;
 export namespace gpsxre::udf
 {
 
-constexpr uint32_t TRAILING_AVDP_SEARCH_SECTORS = 256;
-
-
-constexpr std::optional<uint32_t> get_trailing_avdp_lba(uint32_t partition_end, uint32_t reserve_vds_location, uint32_t reserve_vds_length, uint32_t sector_size)
+constexpr std::optional<uint32_t> get_volume_sectors_count(uint32_t partition_end, uint32_t reserve_vds_location, uint32_t reserve_vds_length, uint32_t sector_size)
 {
     if(!partition_end || !sector_size)
         return std::nullopt;
@@ -23,17 +20,11 @@ constexpr std::optional<uint32_t> get_trailing_avdp_lba(uint32_t partition_end, 
     uint64_t reserve_end = reserve_length ? (uint64_t)reserve_vds_location + reserve_length : 0;
     uint64_t metadata_end = std::max<uint64_t>(partition_end, reserve_end);
 
-    // The sector at metadata_end is the first possible location of the trailing AVDP.
+    // Account for the trailing AVDP immediately following the filesystem metadata.
     if(metadata_end >= std::numeric_limits<uint32_t>::max())
         return std::nullopt;
 
-    return metadata_end;
-}
-
-
-constexpr bool is_trailing_avdp_search_lba(uint32_t lba, uint32_t expected_lba)
-{
-    return lba >= expected_lba && (uint64_t)lba < (uint64_t)expected_lba + TRAILING_AVDP_SEARCH_SECTORS;
+    return metadata_end + 1;
 }
 
 }

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -87,3 +87,8 @@ add_gtest(gtest_bit_copy
     SOURCE  "test_bit_copy.cc"
     MODULES "${CMAKE_SOURCE_DIR}/utils/misc.ixx"
 )
+
+add_gtest(gtest_udf
+    SOURCE  "test_udf.cc"
+    MODULES "${CMAKE_SOURCE_DIR}/filesystem/udf/udf_size.ixx"
+)

--- a/tests/gtest/test_udf.cc
+++ b/tests/gtest/test_udf.cc
@@ -8,43 +8,31 @@ import filesystem.udf_size;
 using namespace gpsxre;
 
 
-TEST(UDF, TrailingAVDPLbaFollowsReserveVDS)
+TEST(UDF, VolumeSectorsCountIncludesReserveVDSAndTrailingAVDP)
 {
     constexpr uint32_t sector_size = 2048;
     constexpr uint32_t partition_start = 277;
     constexpr uint32_t partition_length = 23728682;
-    auto trailing_avdp_lba = udf::get_trailing_avdp_lba(partition_start + partition_length, 23728959, 32768, sector_size);
-
-    ASSERT_EQ(trailing_avdp_lba, 23728975);
-    EXPECT_EQ(*trailing_avdp_lba + 1, 23728976);
+    EXPECT_EQ(udf::get_volume_sectors_count(partition_start + partition_length, 23728959, 32768, sector_size), 23728976);
 }
 
 
-TEST(UDF, TrailingAVDPLbaUsesPartitionEndWithoutReserveVDS)
+TEST(UDF, VolumeSectorsCountUsesPartitionEndWithoutReserveVDS)
 {
-    EXPECT_EQ(udf::get_trailing_avdp_lba(1000, 0, 0, 2048), 1000);
+    EXPECT_EQ(udf::get_volume_sectors_count(1000, 0, 0, 2048), 1001);
 }
 
 
-TEST(UDF, TrailingAVDPLbaUsesLargestMetadataEnd)
+TEST(UDF, VolumeSectorsCountUsesLargestMetadataEnd)
 {
-    EXPECT_EQ(udf::get_trailing_avdp_lba(1000, 500, 2048, 2048), 1000);
-    EXPECT_EQ(udf::get_trailing_avdp_lba(900, 1000, 2049, 2048), 1002);
+    EXPECT_EQ(udf::get_volume_sectors_count(1000, 500, 2048, 2048), 1001);
+    EXPECT_EQ(udf::get_volume_sectors_count(900, 1000, 2049, 2048), 1003);
 }
 
 
-TEST(UDF, TrailingAVDPLbaRejectsInvalidOrOverflowingValues)
+TEST(UDF, VolumeSectorsCountRejectsInvalidOrOverflowingValues)
 {
-    EXPECT_EQ(udf::get_trailing_avdp_lba(0, 0, 0, 2048), std::nullopt);
-    EXPECT_EQ(udf::get_trailing_avdp_lba(1000, 0, 0, 0), std::nullopt);
-    EXPECT_EQ(udf::get_trailing_avdp_lba(1000, std::numeric_limits<uint32_t>::max(), 2048, 2048), std::nullopt);
-}
-
-
-TEST(UDF, TrailingAVDPSearchIsBounded)
-{
-    EXPECT_FALSE(udf::is_trailing_avdp_search_lba(999, 1000));
-    EXPECT_TRUE(udf::is_trailing_avdp_search_lba(1000, 1000));
-    EXPECT_TRUE(udf::is_trailing_avdp_search_lba(1255, 1000));
-    EXPECT_FALSE(udf::is_trailing_avdp_search_lba(1256, 1000));
+    EXPECT_EQ(udf::get_volume_sectors_count(0, 0, 0, 2048), std::nullopt);
+    EXPECT_EQ(udf::get_volume_sectors_count(1000, 0, 0, 0), std::nullopt);
+    EXPECT_EQ(udf::get_volume_sectors_count(1000, std::numeric_limits<uint32_t>::max(), 2048, 2048), std::nullopt);
 }

--- a/tests/gtest/test_udf.cc
+++ b/tests/gtest/test_udf.cc
@@ -1,0 +1,50 @@
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <limits>
+#include <optional>
+
+import filesystem.udf_size;
+
+using namespace gpsxre;
+
+
+TEST(UDF, TrailingAVDPLbaFollowsReserveVDS)
+{
+    constexpr uint32_t sector_size = 2048;
+    constexpr uint32_t partition_start = 277;
+    constexpr uint32_t partition_length = 23728682;
+    auto trailing_avdp_lba = udf::get_trailing_avdp_lba(partition_start + partition_length, 23728959, 32768, sector_size);
+
+    ASSERT_EQ(trailing_avdp_lba, 23728975);
+    EXPECT_EQ(*trailing_avdp_lba + 1, 23728976);
+}
+
+
+TEST(UDF, TrailingAVDPLbaUsesPartitionEndWithoutReserveVDS)
+{
+    EXPECT_EQ(udf::get_trailing_avdp_lba(1000, 0, 0, 2048), 1000);
+}
+
+
+TEST(UDF, TrailingAVDPLbaUsesLargestMetadataEnd)
+{
+    EXPECT_EQ(udf::get_trailing_avdp_lba(1000, 500, 2048, 2048), 1000);
+    EXPECT_EQ(udf::get_trailing_avdp_lba(900, 1000, 2049, 2048), 1002);
+}
+
+
+TEST(UDF, TrailingAVDPLbaRejectsInvalidOrOverflowingValues)
+{
+    EXPECT_EQ(udf::get_trailing_avdp_lba(0, 0, 0, 2048), std::nullopt);
+    EXPECT_EQ(udf::get_trailing_avdp_lba(1000, 0, 0, 0), std::nullopt);
+    EXPECT_EQ(udf::get_trailing_avdp_lba(1000, std::numeric_limits<uint32_t>::max(), 2048, 2048), std::nullopt);
+}
+
+
+TEST(UDF, TrailingAVDPSearchIsBounded)
+{
+    EXPECT_FALSE(udf::is_trailing_avdp_search_lba(999, 1000));
+    EXPECT_TRUE(udf::is_trailing_avdp_search_lba(1000, 1000));
+    EXPECT_TRUE(udf::is_trailing_avdp_search_lba(1255, 1000));
+    EXPECT_FALSE(udf::is_trailing_avdp_search_lba(1256, 1000));
+}


### PR DESCRIPTION
## Summary

- detect UDF from the validated primary Anchor Volume Descriptor Pointer at LBA 256 even when the volume-recognition sequence is absent or not recognized
- preserve the reserve Volume Descriptor Sequence extent and include it when calculating the trimmed filesystem size
- include the trailing AVDP after the larger of the partition end and reserve-VDS end
- add overflow checks and focused UDF size regression tests

## Root cause

The existing trimming path used the partition end plus one sector. On affected BD-R media, the reserve VDS starts at the partition end and extends for another 16 sectors, followed by the trailing AVDP. Trimming at the partition boundary therefore produced a structurally incomplete image.

UDF parsing was also gated on recognizing `NSR02` or `NSR03` in the volume-recognition sequence. A valid primary AVDP is sufficient to identify and process the UDF layout, so this change restores that fallback.

## Impact

Profile-mismatched BD-R media can now be trimmed to the complete recorded UDF filesystem instead of either stopping at the partition boundary or reading the remaining recordable-media capacity.

## Validation

- release build completed successfully on macOS arm64
- all 362 tests passed, including the new UDF regression cases
- physical BD-R test with an HL-DT-ST BU40N:
  - READ CAPACITY: 23,729,248 sectors
  - detected UDF size: 23,728,976 sectors
  - SCSI errors: 0
  - EDC errors: 0
  - output size: 48,596,942,848 bytes
  - CRC32: `03fd2843`
  - MD5: `5283760b72c644cb56cb21a3df5c6acd`
  - SHA-1: `3225512d4f07a14cc08bd3b31aaaee4f42a8ec9a`

The physical-disc output matches [Redump #93203](https://redump.info/disc/93203/).

Fixes #398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDF volume-size detection for discs with reserve and main volume descriptor sequences.
  * Added validation for invalid sector sizes, partition boundaries, and overflowing volume calculations.
  * Improved handling of primary volume descriptor locations and trailing volume descriptors.

* **Tests**
  * Added coverage for reserve metadata, partition-end fallback, metadata endpoint selection, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->