### PR TITLE
fix bad Sector order for ASUS SDRW-08D2S-U LG GP75N-based hardware.

### DIFF
--- a/drive.ixx
+++ b/drive.ixx
@@ -214,7 +214,7 @@ static const std::vector<DriveConfig> DRIVE_DATABASE =
     { "PLEXTOR" , "CD-R PX-W8220T"   , ""    , "", "", +355, 294,  -75, ReadMethod::D8, SectorOrder::DATA_SUB   , Type::PLEXTOR  },
     { "PLEXTOR" , "CD-R PX-W8432T"   , ""    , "", "", +355, 294,  -75, ReadMethod::D8, SectorOrder::DATA_SUB   , Type::PLEXTOR  },
     // OTHER
-    { "ASUS"    , "SDRW-08D2S-U"     , "A812", "", "",    +6,  0,    0, ReadMethod::BE, SectorOrder::DATA_C2_SUB, Type::GENERIC  }, // internal model: LG GP75N
+    { "ASUS"    , "SDRW-08D2S-U"     , "A812", "", "",    +6,  0,    0, ReadMethod::BE, SectorOrder::DATA_SUB_C2, Type::GENERIC  }, // internal model: LG GP75N
     { "ASUS"    , "SDRW-08D2S-U"     , "B901", "", "",    +6,  0, -135, ReadMethod::BE, SectorOrder::DATA_SUB_C2, Type::GENERIC  }, // internal model: DU-8A6NH11B
     { "ASUS"    , "SDRW-08U9M-U"     , "A112", "", "",    +6,  0, -135, ReadMethod::BE, SectorOrder::DATA_SUB_C2, Type::GENERIC  },
     { "Lite-On" , "LTN483S 48x Max"  , "PD03", "", "", -1164,  0,    0, ReadMethod::BE, SectorOrder::DATA_C2    , Type::GENERIC  },


### PR DESCRIPTION
ASUS SDRW-08D2S-U A812 should be using DATA_SUB_C2 codes.

Otherwise it is full of C2 errors.

Seems other LGs based on the Mediatek MT1887 platform needs this. Will confirm later with my other discs.

Interestingly, I noticed the ASUS has a lead-in -135 configured in this file. Will need to see if the ASUS SDRW-08U9M-U actually can, as the firmware is also from an LG-based platform similar to the GP60/GP63/GP65/SP80/GP96.

Not sure if there is a tool that can read or cross-flash, read or dump the MT1887 platform from these drives, since they are all identical hardware but different firmware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sector ordering for the ASUS SDRW-08D2S-U A812 drive to improve data processing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->