### PR TITLE
Force omnidrive flag

### DIFF
--- a/options.ixx
+++ b/options.ixx
@@ -67,6 +67,7 @@ export struct Options
     bool kreon_partial_ss;
     bool dvd_raw;
     bool bd_raw;
+    bool force_omnidrive;
     bool disable_cdtext;
     bool correct_offset_shift;
     bool offset_shift_relocate;
@@ -126,6 +127,7 @@ export struct Options
         , kreon_partial_ss(false)
         , dvd_raw(false)
         , bd_raw(false)
+        , force_omnidrive(false)
         , disable_cdtext(false)
         , correct_offset_shift(false)
         , offset_shift_relocate(false)
@@ -292,6 +294,8 @@ export struct Options
                         dvd_raw = true;
                     else if(key == "--bd-raw")
                         bd_raw = true;
+                    else if(key == "--force-omnidrive")
+                        force_omnidrive = true;
                     else if(key == "--disable-cdtext")
                         disable_cdtext = true;
                     else if(key == "--correct-offset-shift")
@@ -445,6 +449,7 @@ export struct Options
         LOG("\t--kreon-partial-ss              \tget minimal security sector (fixes bad firmware)");
         LOG("\t--dvd-raw                       \tdump raw DVD sectors (OmniDrive)");
         LOG("\t--bd-raw                        \tdump raw BD sectors (OmniDrive)");
+        LOG("\t--force-omnidrive               \tforce OmniDrive mode (if drive enclosure overwrites drive inquiry)");
         LOG("\t--disable-cdtext                \tdisable CD-TEXT reading");
         LOG("");
         LOG("\t(offset)");

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -433,6 +433,14 @@ export int redumper(Options &options)
         drive_override_config(ctx.drive_config, options.drive_type.get(), options.drive_read_offset.get(), options.drive_c2_shift.get(), options.drive_pregap_start.get(),
             options.drive_read_method.get(), options.drive_sector_order.get());
 
+        if(options.force_omnidrive && !is_omnidrive_firmware(ctx.drive_config))
+        {
+            char vvv[3];
+            endian_swap_to_array(vvv, omnidrive_minimum_version());
+            ctx.drive_config.reserved5 = std::string("OmniDrive") + std::string(vvv, sizeof(vvv));
+        }
+
+
         std::optional<GET_CONFIGURATION_FeatureCode_ProfileList> current_profile;
         if(aggregate.drive_ready)
         {

--- a/redumper.ixx
+++ b/redumper.ixx
@@ -43,6 +43,7 @@ import scsi.cmd;
 import scsi.mmc;
 import scsi.sptd;
 import skeleton;
+import utils.endian;
 import utils.file_io;
 import utils.logger;
 import utils.misc;
@@ -439,7 +440,6 @@ export int redumper(Options &options)
             endian_swap_to_array(vvv, omnidrive_minimum_version());
             ctx.drive_config.reserved5 = std::string("OmniDrive") + std::string(vvv, sizeof(vvv));
         }
-
 
         std::optional<GET_CONFIGURATION_FeatureCode_ProfileList> current_profile;
         if(aggregate.drive_ready)


### PR DESCRIPTION
Useful for OmniDrive-flashed drives that are in enclosures that overwrite drive inquiry data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `--force-omnidrive` command-line option to enable OmniDrive compatibility for supported non-OmniDrive firmware.
  - The option is disabled by default and can be enabled when needed.

- **Documentation**
  - Updated command-line help output to describe the new option and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->