### PR TITLE
Add PlayStation disc profiles

### DIFF
--- a/redumper.ixx
+++ b/redumper.ixx
@@ -203,6 +203,13 @@ const std::map<GET_CONFIGURATION_FeatureCode_ProfileList, std::string> PROFILE_S
     { GET_CONFIGURATION_FeatureCode_ProfileList::HDDVD_R_DL,         "HD DVD-R DL"        },
     { GET_CONFIGURATION_FeatureCode_ProfileList::HDDVD_RW_DL,        "HD DVD-RW DL"       },
 
+    { GET_CONFIGURATION_FeatureCode_ProfileList::PS1_CD_ROM,         "PS1 CD-ROM"         },
+    { GET_CONFIGURATION_FeatureCode_ProfileList::PS2_CD_ROM,         "PS2 CD-ROM"         },
+    { GET_CONFIGURATION_FeatureCode_ProfileList::PS2_DVD_ROM,        "PS2 DVD-ROM"        },
+    { GET_CONFIGURATION_FeatureCode_ProfileList::PS3_DVD_ROM,        "PS3 DVD-ROM"        },
+    { GET_CONFIGURATION_FeatureCode_ProfileList::PS3_BD_ROM,         "PS3 BD-ROM"         },
+    { GET_CONFIGURATION_FeatureCode_ProfileList::PS4_BD_ROM,         "PS4 BD-ROM"         },
+
     { GET_CONFIGURATION_FeatureCode_ProfileList::NON_STANDARD,       "NON STANDARD"       }
 };
 
@@ -217,6 +224,8 @@ DiscType profile_to_disc_type(GET_CONFIGURATION_FeatureCode_ProfileList profile)
     case GET_CONFIGURATION_FeatureCode_ProfileList::CD_ROM:
     case GET_CONFIGURATION_FeatureCode_ProfileList::CD_R:
     case GET_CONFIGURATION_FeatureCode_ProfileList::CD_RW:
+    case GET_CONFIGURATION_FeatureCode_ProfileList::PS1_CD_ROM:
+    case GET_CONFIGURATION_FeatureCode_ProfileList::PS2_CD_ROM:
         disc_type = DiscType::CD;
         break;
 
@@ -231,10 +240,14 @@ DiscType profile_to_disc_type(GET_CONFIGURATION_FeatureCode_ProfileList profile)
     case GET_CONFIGURATION_FeatureCode_ProfileList::DVD_PLUS_R:
     case GET_CONFIGURATION_FeatureCode_ProfileList::DVD_PLUS_RW_DL:
     case GET_CONFIGURATION_FeatureCode_ProfileList::DVD_PLUS_R_DL:
+    case GET_CONFIGURATION_FeatureCode_ProfileList::PS2_DVD_ROM:
+    case GET_CONFIGURATION_FeatureCode_ProfileList::PS3_DVD_ROM:
         disc_type = DiscType::DVD;
         break;
 
     case GET_CONFIGURATION_FeatureCode_ProfileList::BD_ROM:
+    case GET_CONFIGURATION_FeatureCode_ProfileList::PS3_BD_ROM:
+    case GET_CONFIGURATION_FeatureCode_ProfileList::PS4_BD_ROM:
         disc_type = DiscType::BLURAY;
         break;
 

--- a/scsi/mmc.ixx
+++ b/scsi/mmc.ixx
@@ -128,6 +128,13 @@ export enum class GET_CONFIGURATION_FeatureCode_ProfileList : uint16_t
     HDDVD_R_DL = 0x58,
     HDDVD_RW_DL = 0x5A,
 
+    PS1_CD_ROM = 0xFF50,
+    PS2_CD_ROM = 0xFF60,
+    PS2_DVD_ROM = 0xFF61,
+    PS3_DVD_ROM = 0xFF70,
+    PS3_BD_ROM = 0xFF71,
+    PS4_BD_ROM = 0xFF80,
+
     NON_STANDARD = 0xFFFF
 };
 


### PR DESCRIPTION
PlayStation 3/4 OEM drives return non-standard values for PlayStation discs.
By adding these profiles to redumper, it will correctly detect and dump PlayStation discs when dumping with PS3/PS4 drives connected to PC, or when dumping on-console (such as with PS4 Linux).

PS5 console/drive is not yet tested, so not sure what PS5 drives or discs do (extrapolating would be 0xFF90 for PS5 discs but won't add until someone tests it).