### PR TITLE
BDXL channel lengths

### DIFF
--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -156,6 +156,8 @@ static const std::string BLURAY_CHANNEL_LENGTH[] =
     "74.5nm",
     "69.0nm",
     "reserved1",
+    "58.26nm",
+    "55.87nm",
     "reserved2",
     "reserved3",
     "reserved4",
@@ -165,9 +167,7 @@ static const std::string BLURAY_CHANNEL_LENGTH[] =
     "reserved8",
     "reserved9",
     "reserved10",
-    "reserved11",
-    "reserved12",
-    "reserved13"
+    "reserved11"
 };
 // clang-format on
 


### PR DESCRIPTION
From ISO 30191
<img width="621" height="155" alt="image" src="https://github.com/user-attachments/assets/0aa66b33-953b-49f5-9f5d-c43a20883795" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Blu-ray channel-length data for two previously unspecified entries.
  - Removed obsolete reserved entries from the channel-length lookup data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->